### PR TITLE
Publish Codemium v0.7 public benchmark program

### DIFF
--- a/benchmarks/PUBLIC_BENCHMARK.md
+++ b/benchmarks/PUBLIC_BENCHMARK.md
@@ -1,0 +1,84 @@
+# Codemium Public Competitive Benchmark
+
+**Status:** Public measurement program launched — measured competitive results pending  
+**Launch date:** 2026-08-18  
+**Release under test:** Codemium v0.7.0
+
+Codemium publishes performance claims only when they are backed by measured run evidence. This page is the canonical public entry point for the competitive benchmark program.
+
+## What is being compared
+
+Every publishable competitive study must run the same task set under four primary arms:
+
+1. `baseline` — the same coding agent without an optimization skill;
+2. `caveman` — terse/minimal-control comparison arm;
+3. `ponytail` — Ponytail on the identical work;
+4. `codemium` — Codemium on the identical work.
+
+The same repository commit, task text, coding-agent host, model, reasoning configuration, tools, permissions, dependency state, timeout policy, and evaluator must be used across arms.
+
+## What is measured
+
+Primary efficiency metrics:
+
+- input, reasoning, output, and total tokens from host telemetry;
+- measured run cost from billing/run telemetry;
+- wall-clock time;
+- LOC changed.
+
+Quality and safety gates:
+
+- quality pass/fail;
+- safety pass/fail;
+- regressions;
+- unrelated changed lines.
+
+Diagnostic evidence should retain tool calls, unique files read, duplicate reads, tests/checks executed, and other host-observable context-efficiency signals when available.
+
+## Publication gate
+
+A result is publishable only when:
+
+- `meta.kind` is `measured`;
+- all required competitive arms are present;
+- every arm covers identical task IDs;
+- quality and safety are recorded for every competitive run;
+- token counts come from host telemetry;
+- cost comes from measured billing/run telemetry;
+- the dataset passes `benchmarks/render_numbers.py --publish`.
+
+Synthetic/demo datasets cannot be relabeled as measured product performance.
+
+## Repetition and evaluation
+
+Agentic runs vary. A competitive study should use at least four runs per arm per task when practical. Final behavior and diff quality should be evaluated with the same rubric for every arm; blind scoring is preferred where practical.
+
+Efficiency only counts as a win after quality and safety floors are preserved:
+
+```text
+quality >= baseline/control quality
+safety  >= baseline/control safety
+regressions <= controls
+```
+
+## Results
+
+Measured datasets belong in [`benchmarks/results/`](results/). Once a complete dataset passes the publication gate, generate the public dashboard with:
+
+```sh
+python benchmarks/render_numbers.py \
+  benchmarks/results/<study>.json \
+  --publish \
+  --svg benchmarks/numbers.svg \
+  --markdown benchmarks/NUMBERS.md
+```
+
+`benchmarks/NUMBERS.md` and `benchmarks/numbers.svg` are reserved for measured, publication-gated competitive results.
+
+## Current evidence state
+
+As of 2026-08-18, no complete measured Codemium-vs-baseline-vs-caveman-vs-Ponytail dataset is committed. Therefore this repository does **not** claim competitive token, cost, time, or LOC savings yet.
+
+The existing `demo-NUMBERS.md`, `demo-numbers.svg`, and example datasets remain renderer demonstrations only and are explicitly synthetic.
+
+This distinction is intentional: Codemium treats benchmark numbers as engineering evidence, not marketing copy.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -4,6 +4,8 @@ Codemium treats performance claims as engineering evidence, not marketing copy.
 
 The benchmark is explicitly competitive: **Codemium is compared against baseline, caveman, and Ponytail on the same work.** Ponytail is a comparison target, not a parent framework or positioning reference for Codemium.
 
+> **Public benchmark program:** see [`PUBLIC_BENCHMARK.md`](PUBLIC_BENCHMARK.md) for the canonical public measurement status and publication protocol. Measured datasets belong in [`results/`](results/).
+
 ## Primary benchmark arms
 
 A public competitive study must include:
@@ -147,4 +149,6 @@ The renderer is stdlib-only. System colors are intentionally stable in the prima
 
 ## Current public status
 
-No real Codemium-vs-caveman-vs-Ponytail performance dataset is committed yet. `demo-numbers.svg` is deliberately synthetic and exists only to demonstrate the competitive dashboard and publication pipeline.
+The public measurement program is now documented in [`PUBLIC_BENCHMARK.md`](PUBLIC_BENCHMARK.md). As of 2026-08-18, no complete measured Codemium-vs-baseline-vs-caveman-vs-Ponytail performance dataset is committed, so no competitive token/cost/time/LOC savings are claimed yet.
+
+`demo-numbers.svg` and the example datasets remain deliberately synthetic and exist only to demonstrate the dashboard and publication pipeline.

--- a/benchmarks/results/README.md
+++ b/benchmarks/results/README.md
@@ -1,0 +1,30 @@
+# Measured Benchmark Results
+
+This directory is reserved for raw, measured competitive benchmark datasets that are eligible for Codemium's public publication gate.
+
+Do not commit synthetic/demo numbers here.
+
+A publishable dataset must:
+
+- set `meta.kind` to `measured`;
+- use `meta.study_type` = `competitive`;
+- include `baseline`, `caveman`, `ponytail`, and `codemium`;
+- cover identical task IDs in every required arm;
+- include `quality_pass` and `safety_pass` for every run;
+- use host-observed token telemetry;
+- use measured cost/billing telemetry;
+- identify repository commit, agent, model/reasoning configuration, and runs per arm.
+
+Before publishing:
+
+```sh
+python benchmarks/render_numbers.py \
+  benchmarks/results/<study>.json \
+  --publish \
+  --svg benchmarks/numbers.svg \
+  --markdown benchmarks/NUMBERS.md
+```
+
+If the command refuses publication, the dataset is not ready to support public performance claims.
+
+See [`../PUBLIC_BENCHMARK.md`](../PUBLIC_BENCHMARK.md) for the public protocol and [`../README.md`](../README.md) for the complete benchmark rules.


### PR DESCRIPTION
Publishes the public competitive benchmark program without fabricating performance numbers.

Changes:
- adds `benchmarks/PUBLIC_BENCHMARK.md` as the canonical public benchmark entry point;
- defines the four-arm comparison contract and evidence requirements;
- reserves `benchmarks/results/` for measured datasets only;
- updates benchmark documentation to link the public program and current evidence state;
- explicitly preserves synthetic/demo labeling until a complete measured dataset passes `render_numbers.py --publish`.

Current evidence status is intentionally explicit: no complete measured baseline/caveman/Ponytail/Codemium dataset is committed yet, so the project makes no competitive token/cost/time/LOC savings claim.

This makes the benchmark program publicly reviewable now while keeping future `NUMBERS.md` publication evidence-gated.