### PR TITLE
Trigger README benchmark publisher

### DIFF
--- a/benchmarks/.trigger-readme-benchmark-pr
+++ b/benchmarks/.trigger-readme-benchmark-pr
@@ -1,0 +1,1 @@
+trigger


### PR DESCRIPTION
One-shot trigger PR used during README benchmark publication. The README was updated directly on `main`, and the temporary publisher workflow/trigger files were removed. This PR is intentionally closed without merge.