### PR TITLE
v0.9: implement Anti-Slop Intelligence / Justified Change Gate

### DIFF
--- a/benchmarks/V09_ANTISLOP_BENCHMARK.md
+++ b/benchmarks/V09_ANTISLOP_BENCHMARK.md
@@ -1,0 +1,146 @@
+# Codemium v0.9 Anti-Slop Benchmark
+
+This benchmark evaluates whether Codemium v0.9 prevents **new unjustified engineering** without removing complexity required for correctness or safety.
+
+The benchmark deliberately measures both error directions:
+
+1. **missed slop** — unnecessary engineering introduced and not prevented;
+2. **over-simplification** — necessary engineering incorrectly removed, blocked, or discouraged.
+
+Correctness and safety are gating metrics. No Anti-Slop efficiency claim is valid when either regresses.
+
+## Arms
+
+Use the same repository state, ticket, host, model/reasoning configuration, tools, dependency state, timeout policy, evaluator, and acceptance criteria for every arm.
+
+- `baseline` — coding agent without Codemium;
+- `codemium_v08` — Codemium v0.8 behavior without Slop Guard;
+- `codemium_v09_guard` — Codemium v0.9 with Justified Change Gate.
+
+Optional ablation:
+
+- `codemium_v09_deterministic` — deterministic/structural findings without reasoned adjudication;
+- `codemium_v09_hybrid` — full deterministic + structural + reasoned adjudication.
+
+Runs must be isolated so one arm cannot inherit conversation, filesystem, Project Brain, or tool state from another arm.
+
+## Task classes
+
+At minimum include:
+
+### 1. Localized bug fix
+
+A small behavior change with a naturally small implementation. Penalize unnecessary helpers, abstractions, configuration, dependencies, unrelated refactors, and debug residue.
+
+### 2. Existing-capability reuse
+
+The repository already contains a suitable helper or abstraction. Measure whether the agent reuses it or creates a duplicate implementation.
+
+### 3. Feature implementation
+
+A task that legitimately needs several changed surfaces. This prevents the benchmark from rewarding minimum LOC regardless of engineering need.
+
+### 4. Security-sensitive change
+
+Authentication/authorization/validation or another trust-boundary task. Slop Guard must not delete required defensive logic merely to simplify the diff.
+
+### 5. Data-integrity / transaction change
+
+A task requiring transaction, locking, idempotency, rollback, or integrity behavior. Necessary complexity must survive Anti-Slop review.
+
+### 6. Compatibility task
+
+A documented compatibility requirement where a shim/fallback is legitimate. This tests false-positive protection for compatibility code.
+
+### 7. Legacy repository
+
+The target file contains unrelated historical debt. Codemium should prevent new slop without turning the task into broad cleanup.
+
+### 8. Cross-language task
+
+A JavaScript/TypeScript/TSX change with graph-backed imported-symbol/dependent/test relationships. This exercises v0.8 Polyglot Intelligence as Anti-Slop evidence.
+
+## Required per-run evidence
+
+Record at minimum:
+
+- `task_id`;
+- `system` / arm;
+- repository start commit;
+- final diff or commit reference;
+- quality/correctness result;
+- safety result;
+- tests/checks executed;
+- regression findings;
+- files changed;
+- LOC changed;
+- unrelated changed lines;
+- new dependencies;
+- new public API surfaces;
+- duplicate implementations introduced;
+- unnecessary abstractions introduced;
+- Slop Guard findings by rule/severity/confidence;
+- false-positive findings;
+- necessary complexity incorrectly removed or blocked;
+- Slop Guard wall-clock overhead;
+- Slop Guard token overhead when observable;
+- analysis coverage and scoreability.
+
+## Primary outcome rules
+
+A v0.9 run is not better merely because it changes fewer lines.
+
+A successful Anti-Slop result must satisfy all of:
+
+1. requested behavior passes;
+2. safety/data-integrity floor is preserved;
+3. no regression is introduced;
+4. introduced unjustified engineering is lower than or equal to the comparison arm;
+5. necessary complexity is not incorrectly removed;
+6. task scope remains bounded.
+
+## False-positive calibration
+
+Blocking rules are high-precision gates. Before release, calibrate them using both positive and negative fixtures.
+
+Positive examples should include:
+
+- unrelated diff;
+- duplicate implementation;
+- unnecessary dependency;
+- single-use forwarding helper;
+- debug residue;
+- type-system escape;
+- speculative fallback;
+- gratuitous abstraction.
+
+Protection examples should include legitimate:
+
+- authentication/authorization checks;
+- validation/sanitization;
+- transactions/locking/idempotency;
+- retry behavior;
+- migration/compatibility paths;
+- public API contracts;
+- test seams;
+- multiple-implementation interfaces.
+
+A false-positive blocker is considered more harmful than a missed cosmetic finding.
+
+## Deterministic fixture
+
+`plugins/codemium/tests/test_slop_guard.py` is the release-regression fixture for the engine. It proves:
+
+- task-scope violations are detected;
+- added debugger/type/comment signals are reported;
+- package dependency deltas are detected;
+- Graph v3 evidence can identify a duplicate implementation and single-use forwarder;
+- strict mode fails on high-confidence blocking findings;
+- protected-complexity removal triggers the Underengineering Counter-Gate;
+- no risk score is fabricated when scoreable source coverage is insufficient.
+
+This fixture validates engine mechanics. It is **not** a substitute for measured multi-arm coding-agent runs.
+
+## Publication gate
+
+Do not publish numeric performance/efficiency claims for v0.9 until representative multi-arm runs satisfy the fairness contract and the raw evidence is retained. If correctness or safety regresses, efficiency results are non-publishable regardless of LOC/token/time improvements.

--- a/plugins/codemium/engine/slop_guard.py
+++ b/plugins/codemium/engine/slop_guard.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import ast
+import fnmatch
+import json
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from common import git, read_json, state_root, write_json
+
+SCHEMA_VERSION = 1
+SOURCE_EXTENSIONS = {".py", ".js", ".jsx", ".ts", ".tsx"}
+TEST_MARKERS = ("/test/", "/tests/", "/__tests__/", ".test.", ".spec.")
+BLOCKING_RULES = {
+    "UNJUSTIFIED_SCOPE",
+    "DUPLICATE_IMPLEMENTATION",
+    "UNJUSTIFIED_DEPENDENCY",
+    "UNJUSTIFIED_PUBLIC_API",
+}
+SEVERITY_WEIGHT = {"BLOCKER": 25, "MAJOR": 12, "MINOR": 4, "INFO": 1}
+PROTECTED_RE = re.compile(
+    r"\b(auth(?:entication|orization)?|permission|role|validat(?:e|ion)|saniti[sz](?:e|ation)|"
+    r"rate.?limit|transaction|rollback|lock(?:ing)?|idempoten(?:t|cy)|retry|migration|compatib(?:ility|le)|"
+    r"integrity|csrf|xss|encrypt(?:ion|ed)?|decrypt(?:ion|ed)?|signature|nonce|secret|token)\b",
+    re.I,
+)
+DEBUG_STRONG_RE = re.compile(r"\b(?:debugger\s*;?|breakpoint\s*\(|pdb\.set_trace\s*\(|console\.(?:debug|trace)\s*\()")
+DEBUG_WEAK_RE = re.compile(r"\b(?:console\.log\s*\(|print\s*\()")
+TYPE_ESCAPE_RE = re.compile(r"(?:#\s*type:\s*ignore|@ts-ignore|@ts-nocheck|\bas\s+any\b|:\s*any\b)")
+PUBLIC_API_RE = re.compile(
+    r"^\s*(?:export\s+(?:default\s+)?(?:async\s+)?(?:function|class|const|let|var|interface|type|enum)\b|__all__\s*=)")
+BROAD_EXCEPTION_RE = re.compile(r"\b(?:except\s+(?:Exception|BaseException)\b|catch\s*\([^)]*\)\s*\{?)")
+NARRATIVE_COMMENT_RE = re.compile(
+    r"^\s*(?:#|//)\s*(?:increment|decrement|set|return|check|initialize|initialise|create|call|loop|iterate|"
+    r"assign|update|delete|remove|add|convert|parse|format|sort|filter|map|open|close|read|write)\b",
+    re.I,
+)
+
+
+@dataclass
+class DiffFile:
+    path: str
+    old_path: str | None = None
+    status: str = "modified"
+    added: list[tuple[int, str]] = field(default_factory=list)
+    removed: list[tuple[int, str]] = field(default_factory=list)
+
+
+@dataclass
+class Finding:
+    rule: str
+    path: str
+    severity: str
+    confidence: float
+    evidence_class: str
+    autofix: str
+    reason: str
+    introduced: str = "introduced"
+    line: int | None = None
+    symbol: str | None = None
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        out = {
+            "rule": self.rule,
+            "path": self.path,
+            "introduced": self.introduced,
+            "severity": self.severity,
+            "confidence": round(self.confidence, 2),
+            "evidence_class": self.evidence_class,
+            "autofix": self.autofix,
+            "reason": self.reason,
+            "evidence": self.evidence,
+        }
+        if self.line is not None:
+            out["line"] = self.line
+        if self.symbol:
+            out["symbol"] = self.symbol
+        return out
+
+
+def _is_test_path(path: str) -> bool:
+    s = "/" + path.lower().replace("\\", "/")
+    name = Path(path).name.lower()
+    return any(x in s for x in TEST_MARKERS) or name.startswith("test_") or name.endswith("_test.py")
+
+
+def _allowed(path: str, patterns: list[str]) -> bool:
+    return any(path == p or fnmatch.fnmatch(path, p) or path.startswith(p.rstrip("/") + "/") for p in patterns)
+
+
+def resolve_diff_scope(root: Path, base: str | None, head: str | None, task: dict) -> dict[str, str]:
+    requested_base = base or task.get("git_base") or task.get("base_ref")
+    if requested_base and git(root, "rev-parse", "--verify", requested_base):
+        resolved_base = requested_base
+        source = "explicit" if base else "task"
+    else:
+        upstream = git(root, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
+        merge_base = git(root, "merge-base", "HEAD", upstream) if upstream else None
+        if merge_base:
+            resolved_base, source = merge_base, "upstream-merge-base"
+        else:
+            resolved_base, source = "HEAD", "head-fallback"
+    resolved_head = head or "WORKTREE"
+    if resolved_head != "WORKTREE" and not git(root, "rev-parse", "--verify", resolved_head):
+        resolved_head = "WORKTREE"
+    return {"base": resolved_base, "head": resolved_head, "source": source}
+
+
+def get_diff(root: Path, scope: dict[str, str]) -> str:
+    base, head = scope["base"], scope["head"]
+    if head == "WORKTREE":
+        return git(root, "diff", "--no-ext-diff", "--unified=0", "--no-color", base, "--") or ""
+    return git(root, "diff", "--no-ext-diff", "--unified=0", "--no-color", f"{base}..{head}", "--") or ""
+
+
+def parse_diff(text: str) -> dict[str, DiffFile]:
+    files: dict[str, DiffFile] = {}
+    current: DiffFile | None = None
+    old_line = new_line = 0
+    for raw in text.splitlines():
+        if raw.startswith("diff --git "):
+            m = re.match(r"diff --git a/(.*?) b/(.*)$", raw)
+            if not m:
+                current = None
+                continue
+            old_path, path = m.group(1), m.group(2)
+            current = DiffFile(path=path, old_path=old_path)
+            files[path] = current
+            continue
+        if current is None:
+            continue
+        if raw.startswith("new file mode"):
+            current.status = "added"
+            continue
+        if raw.startswith("deleted file mode"):
+            current.status = "deleted"
+            continue
+        if raw.startswith("rename from "):
+            current.old_path = raw[len("rename from "):]
+            current.status = "renamed"
+            continue
+        if raw.startswith("rename to "):
+            newp = raw[len("rename to "):]
+            if newp != current.path:
+                files.pop(current.path, None)
+                current.path = newp
+                files[newp] = current
+            current.status = "renamed"
+            continue
+        if raw.startswith("@@"):
+            m = re.search(r"@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@", raw)
+            if m:
+                old_line, new_line = int(m.group(1)), int(m.group(3))
+            continue
+        if raw.startswith("+++") or raw.startswith("---"):
+            continue
+        if raw.startswith("+"):
+            current.added.append((new_line, raw[1:]))
+            new_line += 1
+            continue
+        if raw.startswith("-"):
+            current.removed.append((old_line, raw[1:]))
+            old_line += 1
+            continue
+        if raw.startswith(" "):
+            old_line += 1
+            new_line += 1
+    return files
+
+
+def _task_scope(task: dict) -> list[str]:
+    patterns = list(task.get("working_set") or [])
+    for p in (task.get("working_set_evidence") or {}).keys():
+        if p not in patterns:
+            patterns.append(p)
+    return patterns
+
+
+def classify_surface(path: str, task: dict, graph: dict) -> dict[str, Any]:
+    graph_file = next((f for f in graph.get("files", []) if f.get("path") == path), {})
+    if graph_file.get("is_test") or _is_test_path(path):
+        return {"class": "TEST", "reason": "verification/test surface"}
+    patterns = _task_scope(task)
+    if patterns and not _allowed(path, patterns):
+        return {"class": "UNJUSTIFIED", "reason": "changed path is outside the active task working set"}
+    evidence = (task.get("working_set_evidence") or {}).get(path, [])
+    graph_reasons = [x for x in evidence if x.get("kind") == "graph"]
+    if graph_reasons:
+        best = min(graph_reasons, key=lambda x: int(x.get("distance", 99)))
+        distance = int(best.get("distance", 99))
+        if distance == 0:
+            return {"class": "DIRECT", "reason": "task seed matched structural entity"}
+        return {
+            "class": "DEPENDENCY",
+            "reason": f"structural {best.get('relation') or 'relationship'} at distance {distance}",
+            "provenance": best.get("provenance"),
+        }
+    if patterns:
+        return {"class": "DIRECT", "reason": "included in the active task working set"}
+    return {"class": "DIRECT", "reason": "standalone review target; no active working-set constraint"}
+
+
+def graph_indexes(graph: dict) -> dict[str, Any]:
+    nodes = {n.get("id"): n for n in graph.get("nodes", []) if n.get("id")}
+    symbols_by_path: defaultdict[str, list[dict]] = defaultdict(list)
+    symbols_by_label: defaultdict[str, list[dict]] = defaultdict(list)
+    inbound: Counter[str] = Counter()
+    implementations: Counter[str] = Counter()
+    for n in nodes.values():
+        if n.get("type") == "SYMBOL" and n.get("path"):
+            symbols_by_path[n["path"]].append(n)
+            symbols_by_label[str(n.get("label") or "")].append(n)
+    for e in graph.get("edges", []):
+        target = e.get("target")
+        relation = e.get("relation")
+        if target and relation in {"CALLS", "REFERENCES", "IMPORTS_SYMBOL", "IMPLEMENTS", "INHERITS"}:
+            inbound[target] += 1
+        if target and relation == "IMPLEMENTS":
+            implementations[target] += 1
+    return {
+        "nodes": nodes,
+        "symbols_by_path": symbols_by_path,
+        "symbols_by_label": symbols_by_label,
+        "inbound": inbound,
+        "implementations": implementations,
+    }
+
+
+def _intersects_added(symbol: dict, diff_file: DiffFile) -> bool:
+    start, end = symbol.get("line_start"), symbol.get("line_end")
+    if not isinstance(start, int):
+        return False
+    end = end if isinstance(end, int) and end >= start else start
+    return any(start <= line <= end for line, _ in diff_file.added)
+
+
+def _python_forwarders(path: Path) -> set[str]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return set()
+    out: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) or len(node.body) != 1:
+            continue
+        stmt = node.body[0]
+        if isinstance(stmt, ast.Return) and isinstance(stmt.value, ast.Call):
+            out.add(node.name)
+        elif isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+            out.add(node.name)
+    return out
+
+
+def detect_line_findings(diff_files: dict[str, DiffFile]) -> list[Finding]:
+    findings: list[Finding] = []
+    for path, df in diff_files.items():
+        test_path = _is_test_path(path)
+        for line, text in df.added:
+            if DEBUG_STRONG_RE.search(text):
+                findings.append(Finding("DEBUG_RESIDUE", path, "MAJOR", 0.99, "DETERMINISTIC", "SAFE_MECHANICAL", "debugger/breakpoint residue was added", line=line, evidence={"line": text.strip()}))
+            elif DEBUG_WEAK_RE.search(text) and not test_path:
+                findings.append(Finding("DEBUG_RESIDUE", path, "MINOR", 0.78, "DETERMINISTIC", "REVIEW_REQUIRED", "console/print output was added to production code", line=line, evidence={"line": text.strip()}))
+            if TYPE_ESCAPE_RE.search(text) and not test_path:
+                findings.append(Finding("UNJUSTIFIED_TYPE_ESCAPE", path, "MAJOR", 0.91, "DETERMINISTIC", "REVIEW_REQUIRED", "type-system escape hatch was added", line=line, evidence={"line": text.strip()}))
+            if NARRATIVE_COMMENT_RE.search(text) and len(text.strip()) <= 100 and not test_path:
+                findings.append(Finding("NARRATIVE_COMMENT", path, "MINOR", 0.66, "DETERMINISTIC", "SAFE_MECHANICAL", "comment appears to narrate an obvious operation rather than record rationale", line=line, evidence={"line": text.strip()}))
+            if PUBLIC_API_RE.search(text) and not test_path:
+                findings.append(Finding("UNJUSTIFIED_PUBLIC_API", path, "MINOR", 0.72, "DETERMINISTIC", "REVIEW_REQUIRED", "public/exported API surface was added and requires task-level justification", line=line, evidence={"line": text.strip()}))
+            if BROAD_EXCEPTION_RE.search(text) and not test_path:
+                nearby = [t for ln, t in df.added if line < ln <= line + 5]
+                if any(re.search(r"\b(return|continue|pass|default|fallback)\b", t, re.I) for t in nearby):
+                    findings.append(Finding("SPECULATIVE_FALLBACK", path, "MAJOR", 0.76, "DETERMINISTIC", "REVIEW_REQUIRED", "broad exception path with fallback-like behavior was added", line=line, evidence={"line": text.strip(), "nearby_added": [x.strip() for x in nearby[:5]]}))
+    return findings
+
+
+def _load_json_at_ref(root: Path, ref: str, path: str) -> dict:
+    raw = git(root, "show", f"{ref}:{path}")
+    if raw is None:
+        return {}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+
+
+def detect_dependency_findings(root: Path, scope: dict[str, str], diff_files: dict[str, DiffFile]) -> list[Finding]:
+    findings: list[Finding] = []
+    if "package.json" in diff_files and (root / "package.json").exists():
+        before = _load_json_at_ref(root, scope["base"], "package.json")
+        try:
+            after = json.loads((root / "package.json").read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            after = {}
+        sections = ("dependencies", "devDependencies", "peerDependencies", "optionalDependencies")
+        for section in sections:
+            old = before.get(section, {}) if isinstance(before.get(section), dict) else {}
+            new = after.get(section, {}) if isinstance(after.get(section), dict) else {}
+            for name in sorted(set(new) - set(old)):
+                findings.append(Finding(
+                    "UNJUSTIFIED_DEPENDENCY", "package.json", "MAJOR", 0.98, "DETERMINISTIC", "REVIEW_REQUIRED",
+                    f"new {section} entry requires evidence that project/stdlib/native capability cannot satisfy the task",
+                    evidence={"dependency": name, "version": new.get(name), "section": section},
+                ))
+    for path, df in diff_files.items():
+        name = Path(path).name.lower()
+        if name.startswith("requirements") and name.endswith(".txt"):
+            for line, text in df.added:
+                dep = text.strip()
+                if dep and not dep.startswith(("#", "-", "git+", "http://", "https://")):
+                    findings.append(Finding("UNJUSTIFIED_DEPENDENCY", path, "MAJOR", 0.92, "DETERMINISTIC", "REVIEW_REQUIRED", "new Python dependency entry requires necessity evidence", line=line, evidence={"dependency": dep}))
+        elif name in {"go.mod", "cargo.toml", "gemfile"}:
+            for line, text in df.added:
+                stripped = text.strip()
+                if stripped and not stripped.startswith(("#", "//", "[")):
+                    findings.append(Finding("UNJUSTIFIED_DEPENDENCY", path, "MINOR", 0.68, "DETERMINISTIC", "REVIEW_REQUIRED", "dependency-manifest addition requires review", line=line, evidence={"line": stripped}))
+    return findings
+
+
+def detect_structural_findings(root: Path, graph: dict, idx: dict[str, Any], diff_files: dict[str, DiffFile]) -> list[Finding]:
+    findings: list[Finding] = []
+    for path, df in diff_files.items():
+        symbols = [s for s in idx["symbols_by_path"].get(path, []) if _intersects_added(s, df)]
+        if not symbols:
+            continue
+        py_forwarders = _python_forwarders(root / path) if Path(path).suffix.lower() == ".py" else set()
+        for sym in symbols:
+            sid = sym.get("id")
+            label = str(sym.get("label") or "")
+            subtype = str(sym.get("subtype") or "").lower()
+            inbound = int(idx["inbound"].get(sid, 0))
+            peers = [x for x in idx["symbols_by_label"].get(label, []) if x.get("id") != sid and x.get("path") != path and str(x.get("subtype") or "").lower() == subtype]
+            if label and peers:
+                findings.append(Finding(
+                    "DUPLICATE_IMPLEMENTATION", path, "MAJOR", 0.86, "STRUCTURAL", "REVIEW_REQUIRED",
+                    "a newly changed symbol shares the same repository-level symbol name/type with an existing implementation; inspect reuse before accepting duplication",
+                    line=sym.get("line_start"), symbol=label,
+                    evidence={"existing": [{"path": p.get("path"), "symbol": p.get("qualified_name") or p.get("label")} for p in peers[:5]], "inbound": inbound},
+                ))
+            if subtype in {"function", "method"} and label in py_forwarders and inbound <= 1:
+                findings.append(Finding(
+                    "SINGLE_USE_FORWARDER", path, "MINOR", 0.89, "STRUCTURAL", "REVIEW_REQUIRED",
+                    "single-statement forwarding function has at most one inbound structural consumer",
+                    line=sym.get("line_start"), symbol=label, evidence={"inbound_consumers": inbound},
+                ))
+            if inbound == 0 and subtype in {"function", "method", "class", "interface"} and not label.startswith("test"):
+                findings.append(Finding(
+                    "NEW_DEAD_CODE", path, "MINOR", 0.64, "STRUCTURAL", "REVIEW_REQUIRED",
+                    "newly changed symbol has no inbound structural consumer; entrypoint/reflection use must be ruled out before removal",
+                    line=sym.get("line_start"), symbol=label, evidence={"inbound_consumers": 0},
+                ))
+            if subtype in {"class", "interface"} and inbound <= 1 and int(idx["implementations"].get(sid, 0)) <= 1:
+                findings.append(Finding(
+                    "GRATUITOUS_ABSTRACTION", path, "MINOR", 0.67, "STRUCTURAL", "REVIEW_REQUIRED",
+                    "new abstraction has limited structural consumers/implementations and needs architecture justification",
+                    line=sym.get("line_start"), symbol=label,
+                    evidence={"inbound_consumers": inbound, "implementations": int(idx["implementations"].get(sid, 0))},
+                ))
+        if df.status == "added":
+            code_lines = [t for _, t in df.added if t.strip() and not t.lstrip().startswith(("#", "//"))]
+            inbound_total = sum(int(idx["inbound"].get(s.get("id"), 0)) for s in symbols)
+            if len(symbols) <= 1 and len(code_lines) <= 10 and inbound_total <= 1 and not _is_test_path(path):
+                findings.append(Finding(
+                    "UNNECESSARY_FILE", path, "MINOR", 0.7, "STRUCTURAL", "REVIEW_REQUIRED",
+                    "new small file contains at most one changed symbol and little structural reuse evidence",
+                    evidence={"changed_symbols": len(symbols), "code_lines": len(code_lines), "inbound_consumers": inbound_total},
+                ))
+    return findings
+
+
+def detect_scope_findings(classifications: dict[str, dict[str, Any]]) -> list[Finding]:
+    out = []
+    for path, info in classifications.items():
+        if info.get("class") == "UNJUSTIFIED":
+            out.append(Finding("UNJUSTIFIED_SCOPE", path, "MAJOR", 0.99, "DETERMINISTIC", "REVIEW_REQUIRED", info.get("reason") or "changed surface is not justified by active task scope"))
+    return out
+
+
+def protected_complexity(diff_files: dict[str, DiffFile]) -> dict[str, Any]:
+    added, removed = [], []
+    for path, df in diff_files.items():
+        for line, text in df.added:
+            if PROTECTED_RE.search(text):
+                added.append({"path": path, "line": line, "text": text.strip()})
+        for line, text in df.removed:
+            if PROTECTED_RE.search(text):
+                removed.append({"path": path, "line": line, "text": text.strip()})
+    return {
+        "added": added[:50],
+        "removed": removed[:50],
+        "underengineering_gate": {
+            "status": "review_required" if removed else "pass",
+            "reason": "protected-complexity lines were removed; verify behavior/security/data-integrity intent" if removed else "no protected-complexity removal signal detected",
+        },
+    }
+
+
+def coverage(graph: dict, diff_files: dict[str, DiffFile]) -> dict[str, Any]:
+    graph_files = {f.get("path"): f for f in graph.get("files", []) if f.get("path")}
+    source_added = analyzable_added = 0
+    changed_source_files = structurally_covered = 0
+    for path, df in diff_files.items():
+        if Path(path).suffix.lower() not in SOURCE_EXTENSIONS:
+            continue
+        changed_source_files += 1
+        source_added += len(df.added)
+        rec = graph_files.get(path)
+        if rec:
+            structurally_covered += 1
+            caps = rec.get("capabilities") or {}
+            if rec.get("parser") in {"python-ast", "tree-sitter-javascript", "tree-sitter-typescript", "tree-sitter-tsx"} or caps.get("symbols"):
+                analyzable_added += len(df.added)
+    changed_line_coverage = 1.0 if source_added == 0 else analyzable_added / source_added
+    structural_coverage = 1.0 if changed_source_files == 0 else structurally_covered / changed_source_files
+    scoreable = source_added > 0 and changed_line_coverage >= 0.5 and structural_coverage >= 0.5
+    return {
+        "changed_lines": round(changed_line_coverage, 3),
+        "structural": round(structural_coverage, 3),
+        "source_added_lines": source_added,
+        "changed_source_files": changed_source_files,
+        "scoreable": scoreable,
+    }
+
+
+def risk_score(findings: list[Finding], scoreable: bool) -> int | None:
+    if not scoreable:
+        return None
+    total = 0.0
+    for f in findings:
+        if f.introduced not in {"introduced", "worsened"}:
+            continue
+        total += SEVERITY_WEIGHT.get(f.severity, 1) * f.confidence
+    return min(100, int(round(total)))
+
+
+def dedupe_findings(findings: list[Finding]) -> list[Finding]:
+    seen = set()
+    out = []
+    for f in findings:
+        key = (f.rule, f.path, f.line, f.symbol, f.reason)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(f)
+    return out
+
+
+def verdict(findings: list[Finding], protected: dict[str, Any]) -> str:
+    for f in findings:
+        if f.introduced in {"introduced", "worsened"} and f.confidence >= 0.85 and (f.severity == "BLOCKER" or f.rule in BLOCKING_RULES):
+            return "fail"
+    if protected["underengineering_gate"]["status"] != "pass":
+        return "review"
+    if any(f.severity == "MAJOR" and f.confidence >= 0.6 for f in findings):
+        return "review"
+    return "pass"
+
+
+def analyze(root: Path, base: str | None = None, head: str | None = None) -> dict[str, Any]:
+    root = root.resolve()
+    state = state_root(root)
+    task = read_json(state / "tasks/active.json", {})
+    graph = read_json(state / "repository/graph.json", {})
+    scope = resolve_diff_scope(root, base, head, task)
+    diff_files = parse_diff(get_diff(root, scope))
+    classifications = {path: classify_surface(path, task, graph) for path in sorted(diff_files)}
+    idx = graph_indexes(graph)
+    findings = []
+    findings.extend(detect_scope_findings(classifications))
+    findings.extend(detect_line_findings(diff_files))
+    findings.extend(detect_dependency_findings(root, scope, diff_files))
+    findings.extend(detect_structural_findings(root, graph, idx, diff_files))
+    findings = dedupe_findings(findings)
+    protected = protected_complexity(diff_files)
+    cov = coverage(graph, diff_files)
+    status = verdict(findings, protected)
+    classes = Counter(x.get("class") for x in classifications.values())
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "scope": scope,
+        "risk_score": risk_score(findings, bool(cov["scoreable"])),
+        "scoreable": bool(cov["scoreable"]),
+        "coverage": {k: v for k, v in cov.items() if k != "scoreable"},
+        "changed_files": len(diff_files),
+        "surfaces": {
+            "direct": classes.get("DIRECT", 0),
+            "dependency": classes.get("DEPENDENCY", 0),
+            "cleanup": classes.get("CLEANUP", 0),
+            "test": classes.get("TEST", 0),
+            "unjustified": classes.get("UNJUSTIFIED", 0),
+        },
+        "surface_classification": classifications,
+        "findings": [f.as_dict() for f in findings],
+        "protected_complexity": protected,
+        "underengineering_gate": protected["underengineering_gate"],
+    }
+
+
+def human_report(report: dict[str, Any]) -> str:
+    score = report.get("risk_score")
+    score_text = f"{score}/100" if score is not None else "N/A (insufficient scoreable coverage)"
+    lines = [
+        "CODEMIUM SLOP GUARD",
+        "",
+        f"Scope: {report['scope']['base']} -> {report['scope']['head']} ({report['scope']['source']})",
+        f"Changed files: {report['changed_files']}",
+        f"Slop Risk: {score_text}",
+        f"Coverage: changed-lines {report['coverage']['changed_lines']:.0%}, structural {report['coverage']['structural']:.0%}",
+        f"Status: {report['status'].upper()}",
+        "",
+        "Surfaces: " + ", ".join(f"{k}={v}" for k, v in report["surfaces"].items()),
+        f"Underengineering gate: {report['underengineering_gate']['status'].upper()}",
+    ]
+    findings = report.get("findings", [])
+    if findings:
+        lines.extend(["", "Introduced findings:"])
+        for f in findings:
+            loc = f"{f['path']}:{f['line']}" if f.get("line") else f["path"]
+            symbol = f" [{f['symbol']}]" if f.get("symbol") else ""
+            lines.append(f"- {f['severity']} {f['rule']} @ {loc}{symbol} ({f['confidence']:.0%})")
+    else:
+        lines.extend(["", "Introduced findings: none"])
+    return "\n".join(lines)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Codemium v0.9 task-aware Anti-Slop / Justified Change Gate")
+    ap.add_argument("--root", default=".")
+    ap.add_argument("--base")
+    ap.add_argument("--head")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--write-state", action="store_true")
+    ap.add_argument("--strict", action="store_true")
+    ns = ap.parse_args()
+    report = analyze(Path(ns.root), ns.base, ns.head)
+    if ns.write_state:
+        write_json(state_root(Path(ns.root)) / "runtime/slop-report.json", report)
+    print(json.dumps(report, indent=2, ensure_ascii=False) if ns.json else human_report(report))
+    if ns.strict and report["status"] != "pass":
+        raise SystemExit(3 if report["status"] == "fail" else 2)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/codemium/skills/codemium/SKILL.md
+++ b/plugins/codemium/skills/codemium/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cm
-description: "Primary Codemium skill for OpenAI Codex: auto-detect coding task and engineering depth, reuse persistent project intelligence, use evidence-backed Polyglot Intelligence, select bounded context, make the smallest justified change, verify by risk, and stop when proven."
+description: "Primary Codemium skill for OpenAI Codex: auto-detect coding task and engineering depth, reuse persistent project intelligence, use evidence-backed Polyglot Intelligence, select bounded context, make the smallest justified change, verify by risk, run the v0.9 Slop Guard, and stop when proven."
 ---
 
 # Codemium
@@ -25,7 +25,7 @@ Direct Agent Skill invocation remains available as an advanced/compatibility pat
 - `$cm deep` → requested DEEP depth;
 - `$cm critical` → requested CRITICAL depth.
 
-Focused direct skills such as `$cm-fix`, `$cm-test`, and `$cm-review` pin task type but use the same depth/reasoning policy. They are implementation-level shortcuts, not the primary public UX.
+Focused direct skills such as `$cm-fix`, `$cm-test`, `$cm-review`, and `$cm-slop` pin a narrower intent but use the same safety/reasoning policy. They are implementation-level shortcuts, not the primary public UX.
 
 ## Lightweight Project Brain memory mode
 
@@ -94,6 +94,36 @@ Tests/runtime     → behavioral proof
 Project Brain     → durable engineering knowledge, freshness-qualified
 ```
 
+## Anti-Slop Intelligence contract — v0.9
+
+Codemium targets the **minimum justified engineering surface**, not minimum LOC. Near completion of a normal source-changing task, use Slop Guard as a task-aware **Justified Change Gate** when the deterministic helper is available.
+
+Default Guard Mode is changed-surface-first:
+
+```text
+actual task diff
+→ changed symbols
+→ bounded graph evidence
+→ relevant source/tests
+```
+
+- Classify every changed surface as `DIRECT`, `DEPENDENCY`, `CLEANUP`, or `TEST`. Internal `UNJUSTIFIED` is not a valid completion state: justify it with concrete evidence or remove it.
+- Focus completion gates on engineering introduced or worsened by this task. Do not turn nearby pre-existing debt into an unrequested cleanup campaign.
+- Prefer deterministic findings, then Structural Graph v3 evidence, then evidence-backed reasoned adjudication for ambiguity.
+- Treat the aggregate Slop Risk score as informational only. Honor `scoreable` and coverage output; never invent a score when structural/source coverage is insufficient.
+- High-confidence findings in unjustified scope, duplicate implementation, unjustified dependency, or unjustified public API expansion must be resolved before completion.
+- Run the **Underengineering Counter-Gate** before accepting simplification. Preserve necessary authentication/authorization, validation/sanitization, rate limiting, transactions/locking/idempotency, retry behavior, data-integrity checks, migrations/compatibility, security checks, and tests.
+- Safe mechanical cleanup may be automatic only when confidence is high and behavioral risk is low. Abstraction removal, fallback removal, dependency replacement, public API reduction, compatibility changes, or test changes require review.
+- After any cleanup, re-run affected and impact-mapped verification, inspect the new actual diff, and run Slop Guard again. High-impact simplification requires a logically separate review pass.
+
+Typical helper invocation from the plugin root:
+
+```sh
+python plugins/codemium/engine/slop_guard.py --root . --json --write-state
+```
+
+Read `references/slop-policy.md` when a finding is ambiguous or cleanup materially changes design/safety.
+
 ## Reasoning profile
 
 Engineering depth is portable Codemium behavior. Codex reasoning effort is a host-specific preference layered on top.
@@ -134,9 +164,10 @@ Use `engine/reasoning_profile.py` for deterministic profile/alignment output. Re
 9. Make the smallest **justified** change, not the shortest diff.
 10. Inspect actual git diff; classify every changed surface as DIRECT, DEPENDENCY, caused CLEANUP, or TEST. Use structural Working Set evidence to explain dependency/test surfaces where available.
 11. Run symbol-aware structural impact/test mapping. Inspect high-score/cross-language dependents and execute the strongest relevant P0/P1 tests first, expanding verification according to risk/depth. Inspect source/tests for any heuristic-only relationship that materially affects the decision.
-12. Revalidate relevant stale Project Brain facts, then distill and capture only durable new project knowledge; never store a transcript or secrets.
-13. Complete/clear transient task state when applicable.
-14. Stop once acceptance, verification, scope, persistence, freshness, and material uncertainty gates pass.
+12. Run v0.9 Slop Guard on the actual task diff. Resolve high-confidence introduced/worsened blockers and run the Underengineering Counter-Gate. If cleanup changes source, re-run relevant verification, impact/diff inspection, and Slop Guard before continuing.
+13. Revalidate relevant stale Project Brain facts, then distill and capture only durable new project knowledge; never store a transcript or secrets.
+14. Complete/clear transient task state when applicable.
+15. Stop once acceptance, verification, justified-surface/Anti-Slop, persistence, freshness, and material uncertainty gates pass.
 
 The lifecycle above does **not** run while `CODEMIUM MEMORY RETRIEVAL MODE` is active.
 
@@ -171,13 +202,14 @@ Do not read references up front. Use them only when the corresponding decision a
 - task-specific policy → `references/task-modes.md`
 - testing → `references/testing-policy.md`
 - scope/diff → `references/scope-policy.md`
+- Anti-Slop/justification → `references/slop-policy.md`
 - project memory → `references/project-brain.md`
 - security/high-risk → `references/security-policy.md`
 - model migration → `references/model-capabilities.md`
 
 ## Deterministic helpers
 
-Use scripts in `engine/` when useful for Project Brain initialization/capture/freshness, parser-aware repository graph refresh/query, graph-assisted Working Set ranking, symbol-aware impact/test mapping, reasoning-profile alignment, cache checks, health, or telemetry. Tools establish facts; model reasoning handles root cause, tradeoffs, risk, and acceptance.
+Use scripts in `engine/` when useful for Project Brain initialization/capture/freshness, parser-aware repository graph refresh/query, graph-assisted Working Set ranking, symbol-aware impact/test mapping, Slop Guard, reasoning-profile alignment, cache checks, health, or telemetry. Tools establish facts; model reasoning handles root cause, tradeoffs, risk, and acceptance.
 
 ## Anti-overengineering ladder
 
@@ -193,4 +225,4 @@ A short diff can still be wrong-scoped. Do not modernize, rename, format, refact
 
 ## Completion
 
-Continue only if you can name an unresolved material risk or persistence obligation the next operation will reduce. Otherwise stop and report: result/root cause, changed, verified, durable knowledge captured/reused/none, freshness/revalidation performed when relevant, residual risk.
+Continue only if you can name an unresolved material risk, unjustified changed surface, underengineering concern, or persistence obligation the next operation will reduce. Otherwise stop and report: result/root cause, changed, verified, Slop Guard result, protected complexity retained or reviewed, durable knowledge captured/reused/none, freshness/revalidation performed when relevant, residual risk.

--- a/plugins/codemium/skills/codemium/references/slop-policy.md
+++ b/plugins/codemium/skills/codemium/references/slop-policy.md
@@ -1,0 +1,103 @@
+# Anti-Slop / Justified Change Policy
+
+Codemium optimizes for the **minimum justified engineering surface**, not minimum LOC, files, abstractions, or dependencies.
+
+## Core rule
+
+Every changed surface must be defensible as one of:
+
+- `DIRECT` — implements requested behavior;
+- `DEPENDENCY` — required for a direct change to work safely;
+- `CLEANUP` — code made obsolete by this exact change;
+- `TEST` — evidence for changed behavior.
+
+`UNJUSTIFIED` is an internal Slop Guard state, never a valid completion state. Before completion it must become justified by evidence or be removed.
+
+## Guard before cleanup
+
+Normal source-changing Codemium tasks should run Slop Guard near completion against the actual task diff. Guard Mode is analysis-first. It must not turn a bounded feature/fix into repository-wide cleanup.
+
+Default scope is:
+
+```text
+actual diff
+→ changed symbols
+→ bounded structural neighbors
+→ relevant tests/evidence
+```
+
+Pre-existing debt is reported separately when useful but is not automatically part of the task. Completion gates focus on slop introduced or worsened by the current task.
+
+## Evidence order
+
+Use the strongest available evidence:
+
+1. deterministic diff/source facts;
+2. Structural Graph v3 evidence;
+3. evidence-backed reasoning for ambiguity.
+
+Do not block or remove code because it merely "looks over-engineered." Source remains authoritative.
+
+## Coverage honesty
+
+A Slop Risk score is informational. Never fabricate one when changed-source coverage is insufficient. Report scoreability and analysis coverage explicitly, then degrade to ordinary source review.
+
+## Protected complexity / underengineering gate
+
+Anti-Slop must reject underengineering as well as overengineering. Do not blindly remove or weaken:
+
+- authentication or authorization;
+- validation or sanitization;
+- rate limiting;
+- transactions, locking, rollback, or idempotency;
+- retry behavior;
+- data-integrity checks;
+- migrations or compatibility paths;
+- security checks;
+- tests.
+
+If simplification touches these surfaces, inspect intent and behavioral evidence before accepting it. When ambiguity remains, preserve the safer implementation.
+
+## Cleanup policy
+
+Safe mechanical cleanup may be automated only at high confidence and low behavioral risk. Abstraction removal, helper consolidation, fallback removal, dependency replacement, public API reduction, compatibility changes, and test changes require review.
+
+After any cleanup:
+
+```text
+cleanup
+→ affected tests
+→ impact-mapped tests
+→ actual diff review
+→ Slop Guard re-check
+```
+
+High-impact simplification should receive a logically separate review pass. The writer must not silently approve its own destructive simplification.
+
+## Dependencies and abstractions
+
+Before accepting a new dependency or abstraction, check:
+
+```text
+actual need
+→ existing project solution
+→ standard library
+→ native platform/framework
+→ existing dependency
+→ simple local implementation
+→ new abstraction/dependency
+```
+
+A single implementation or single caller is only a signal. Architecture boundaries, public contracts, test seams, lifecycle separation, cross-language boundaries, or explicit project constraints can fully justify an abstraction.
+
+## Completion
+
+A source-changing task may complete when:
+
+- requested behavior is satisfied;
+- relevant verification passes;
+- no high-confidence introduced blocker remains unexplained;
+- every changed surface is justified;
+- protected complexity has not been accidentally removed;
+- cleanup, if any, has been re-verified;
+- persistence/freshness obligations are satisfied.

--- a/plugins/codemium/skills/slop/SKILL.md
+++ b/plugins/codemium/skills/slop/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: cm-slop
+description: "Codemium v0.9 Anti-Slop review: inspect the actual task diff for unjustified engineering, preserve necessary complexity, and re-verify any cleanup."
+---
+
+# $cm-slop
+
+Review the actual diff using Codemium's **Justified Change Gate**. The target is the **minimum justified engineering surface**, not minimum LOC.
+
+## Default behavior
+
+Use review/Guard Mode first. When `engine/slop_guard.py` is available, run it against the repository root and inspect its evidence:
+
+```sh
+python engine/slop_guard.py --root . --json --write-state
+```
+
+Repository-root plugin installs may instead expose the helper under `plugins/codemium/engine/slop_guard.py`.
+
+Resolve findings with this authority order:
+
+```text
+deterministic diff/source evidence
+→ Structural Graph v3 evidence
+→ evidence-backed reasoning
+```
+
+Do not accept or remove code merely because the aggregate risk score is high or low. The score is informational and may be unavailable when coverage is insufficient.
+
+## Changed-surface discipline
+
+Classify every changed surface as `DIRECT`, `DEPENDENCY`, `CLEANUP`, or `TEST`. `UNJUSTIFIED` is temporary: either establish concrete task/architecture/safety evidence for it or remove it.
+
+Focus on engineering introduced or worsened by the current task. Do not turn a bounded task into a repository-wide cleanup campaign because unrelated historical slop exists nearby.
+
+## Cleanup
+
+Only perform cleanup when the user requested cleanup or when a normal Codemium implementation task has a high-confidence introduced finding whose removal is low-risk and clearly preserves requested behavior.
+
+Safe mechanical cleanup can include obvious debugger residue or redundant narration. Do not blindly remove abstractions, fallbacks, dependencies, compatibility code, public APIs, tests, validation, authentication/authorization, transactions, locking, idempotency, retry behavior, or data-integrity checks.
+
+After any cleanup, re-run the relevant verification and inspect the actual diff again. High-impact simplification requires a logically separate review pass.
+
+## Underengineering counter-gate
+
+Before approving simplification, explicitly check whether it removed necessary failure handling, security boundaries, data integrity, concurrency controls, compatibility, public contracts, observability, or test confidence. When evidence is insufficient, preserve the safer implementation.
+
+Read `references/slop-policy.md` when a Slop Guard decision is ambiguous or materially affects implementation.
+
+## Completion
+
+Report:
+
+- diff scope used;
+- pass/review/fail result;
+- introduced/worsened findings that matter;
+- any protected complexity intentionally retained;
+- cleanup performed, if any;
+- verification repeated after cleanup;
+- residual uncertainty.

--- a/plugins/codemium/tests/test_slop_guard.py
+++ b/plugins/codemium/tests/test_slop_guard.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+PLUGIN = Path(__file__).resolve().parents[1]
+ENGINE = PLUGIN / "engine"
+
+
+def run(*args, cwd=None, ok=True):
+    p = subprocess.run([str(x) for x in args], cwd=cwd, capture_output=True, text=True)
+    if ok and p.returncode != 0:
+        print(p.stdout)
+        print(p.stderr, file=sys.stderr)
+        raise AssertionError(f"command failed {p.returncode}: {args}")
+    return p
+
+
+def init_repo(root: Path) -> None:
+    run("git", "init", "-q", cwd=root)
+    run("git", "config", "user.email", "fixture@example.com", cwd=root)
+    run("git", "config", "user.name", "Fixture", cwd=root)
+
+
+def commit(root: Path, message: str = "initial") -> None:
+    run("git", "add", ".", cwd=root)
+    run("git", "commit", "-qm", message, cwd=root)
+
+
+def main() -> None:
+    # Introduced-slop fixture: task scope, line-level smells, dependency delta,
+    # duplicate implementation, and single-use forwarder must all be evidence-backed.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        (root / "src").mkdir()
+        init_repo(root)
+        (root / "src/utils.py").write_text("def normalize_value(x):\n    return x\n", encoding="utf-8")
+        (root / "src/service.py").write_text("def process(x):\n    return x\n", encoding="utf-8")
+        (root / "src/unrelated.py").write_text("def untouched():\n    return 1\n", encoding="utf-8")
+        (root / "src/security.py").write_text(
+            "def validate_token(token):\n    if not token:\n        raise ValueError('token')\n    return token\n",
+            encoding="utf-8",
+        )
+        (root / "package.json").write_text(json.dumps({"dependencies": {}}, indent=2) + "\n", encoding="utf-8")
+        commit(root)
+
+        (root / "src/service.py").write_text(
+            "from src.utils import normalize_value\n\n"
+            "def process(x):\n    return x\n\n"
+            "# Increment counter\n"
+            "def normalize_value(x):\n    return x\n\n"
+            "def pass_through(x):\n    return normalize_value(x)\n\n"
+            "print(\"debug\")\n"
+            "value = None  # type: ignore\n",
+            encoding="utf-8",
+        )
+        (root / "src/unrelated.py").write_text("def untouched():\n    return 2\n", encoding="utf-8")
+        (root / "package.json").write_text(
+            json.dumps({"dependencies": {"left-pad": "1.3.0"}}, indent=2) + "\n", encoding="utf-8"
+        )
+
+        state = root / ".codemium"
+        (state / "tasks").mkdir(parents=True)
+        (state / "repository").mkdir()
+        (state / "tasks/active.json").write_text(
+            json.dumps({"working_set": ["src/service.py", "package.json"]}), encoding="utf-8"
+        )
+        graph = {
+            "files": [
+                {"path": "src/service.py", "language": "python", "is_test": False, "parser": "python-ast", "capabilities": {"symbols": True}},
+                {"path": "src/utils.py", "language": "python", "is_test": False, "parser": "python-ast", "capabilities": {"symbols": True}},
+                {"path": "src/unrelated.py", "language": "python", "is_test": False, "parser": "python-ast", "capabilities": {"symbols": True}},
+            ],
+            "nodes": [
+                {"id": "s:util:norm", "type": "SYMBOL", "subtype": "function", "label": "normalize_value", "qualified_name": "normalize_value", "path": "src/utils.py", "line_start": 1, "line_end": 2},
+                {"id": "s:svc:process", "type": "SYMBOL", "subtype": "function", "label": "process", "qualified_name": "process", "path": "src/service.py", "line_start": 3, "line_end": 4},
+                {"id": "s:svc:norm", "type": "SYMBOL", "subtype": "function", "label": "normalize_value", "qualified_name": "normalize_value", "path": "src/service.py", "line_start": 7, "line_end": 8},
+                {"id": "s:svc:pass", "type": "SYMBOL", "subtype": "function", "label": "pass_through", "qualified_name": "pass_through", "path": "src/service.py", "line_start": 10, "line_end": 11},
+                {"id": "s:unrelated", "type": "SYMBOL", "subtype": "function", "label": "untouched", "qualified_name": "untouched", "path": "src/unrelated.py", "line_start": 1, "line_end": 2},
+            ],
+            "edges": [
+                {"source": "s:svc:pass", "target": "s:svc:norm", "relation": "CALLS", "provenance": "RESOLVED"}
+            ],
+        }
+        (state / "repository/graph.json").write_text(json.dumps(graph), encoding="utf-8")
+
+        p = run(sys.executable, ENGINE / "slop_guard.py", "--root", root, "--base", "HEAD", "--json")
+        report = json.loads(p.stdout)
+        rules = {f["rule"] for f in report["findings"]}
+        for rule in [
+            "UNJUSTIFIED_SCOPE",
+            "DEBUG_RESIDUE",
+            "UNJUSTIFIED_TYPE_ESCAPE",
+            "NARRATIVE_COMMENT",
+            "UNJUSTIFIED_DEPENDENCY",
+            "DUPLICATE_IMPLEMENTATION",
+            "SINGLE_USE_FORWARDER",
+        ]:
+            assert rule in rules, (rule, rules)
+        assert report["status"] == "fail", report
+        assert report["surfaces"]["unjustified"] == 1
+        assert report["scoreable"] is True and report["risk_score"] is not None
+        assert report["underengineering_gate"]["status"] == "pass"
+
+        strict = run(
+            sys.executable,
+            ENGINE / "slop_guard.py",
+            "--root",
+            root,
+            "--base",
+            "HEAD",
+            "--json",
+            "--strict",
+            ok=False,
+        )
+        assert strict.returncode == 3, strict.returncode
+
+    # Underengineering fixture: removing protected complexity must force review,
+    # and a score must not be fabricated when there are no scoreable added source lines.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        (root / "src").mkdir()
+        init_repo(root)
+        (root / "src/security.py").write_text(
+            "def validate_token(token):\n    if not token:\n        raise ValueError('token required')\n    return token\n",
+            encoding="utf-8",
+        )
+        commit(root)
+        (root / "src/security.py").write_text("def validate_token(token):\n    return token\n", encoding="utf-8")
+
+        state = root / ".codemium"
+        (state / "tasks").mkdir(parents=True)
+        (state / "repository").mkdir()
+        (state / "tasks/active.json").write_text(json.dumps({"working_set": ["src/security.py"]}), encoding="utf-8")
+        graph = {
+            "files": [
+                {"path": "src/security.py", "language": "python", "is_test": False, "parser": "python-ast", "capabilities": {"symbols": True}}
+            ],
+            "nodes": [],
+            "edges": [],
+        }
+        (state / "repository/graph.json").write_text(json.dumps(graph), encoding="utf-8")
+
+        p = run(sys.executable, ENGINE / "slop_guard.py", "--root", root, "--base", "HEAD", "--json")
+        report = json.loads(p.stdout)
+        assert report["underengineering_gate"]["status"] == "review_required", report
+        assert report["status"] == "review", report
+        assert report["risk_score"] is None and report["scoreable"] is False
+
+    print("PASS: Codemium v0.9 Slop Guard deterministic + structural + underengineering fixture")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_core.py
+++ b/scripts/verify_core.py
@@ -14,7 +14,7 @@ TESTS = ROOT / "plugins/codemium/tests"
 
 REQUIRED_ENGINE = [
     "common.py", "project_brain.py", "parsers.py", "repo_graph.py", "graph_query.py", "working_set.py", "impact.py",
-    "scope_guard.py", "test_map.py", "cache.py", "telemetry.py", "health.py", "reasoning_profile.py", "task_compiler.py",
+    "scope_guard.py", "slop_guard.py", "test_map.py", "cache.py", "telemetry.py", "health.py", "reasoning_profile.py", "task_compiler.py",
 ]
 
 
@@ -22,53 +22,105 @@ def fail(message: str) -> None:
     raise SystemExit(f"FAIL: {message}")
 
 
+def run_fixture(path: Path, label: str) -> None:
+    if not path.exists():
+        fail(f"missing {label} fixture")
+    py_compile.compile(str(path), doraise=True)
+    result = subprocess.run([sys.executable, str(path)], cwd=ROOT, text=True, capture_output=True)
+    if result.returncode != 0:
+        sys.stdout.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        fail(f"{label} fixture failed")
+
+
 def main() -> None:
     version = (ROOT / "VERSION").read_text(encoding="utf-8").strip()
-    if not version: fail("VERSION is empty")
+    if not version:
+        fail("VERSION is empty")
     for name in REQUIRED_ENGINE:
         path = ENGINE / name
-        if not path.exists(): fail(f"missing engine/{name}")
+        if not path.exists():
+            fail(f"missing engine/{name}")
         py_compile.compile(str(path), doraise=True)
+
     fixture = TESTS / "test_core_fixture.py"
-    if not fixture.exists(): fail("missing host-agnostic core fixture")
-    py_compile.compile(str(fixture), doraise=True)
+    slop_fixture = TESTS / "test_slop_guard.py"
 
     brain = (ENGINE / "project_brain.py").read_text(encoding="utf-8")
     for phrase in ["GENERIC_REASONING", "TRANSIENT_IGNORE", "tasks/active.json", "host_profiles", "def capture(", "find_active_duplicate", "init(root, emit=False)", "def entry_freshness(", "NEEDS_REVALIDATION", "def revalidate("]:
-        if phrase not in brain: fail(f"Project Brain contract missing: {phrase}")
+        if phrase not in brain:
+            fail(f"Project Brain contract missing: {phrase}")
     parsers = (ENGINE / "parsers.py").read_text(encoding="utf-8")
     for phrase in ["class ParserAdapter", "class PythonAstParser", "class TreeSitterJSTSParser", "class RegexFallbackParser", "fallback-regex", "PARSER_VERSION = \"3\""]:
-        if phrase not in parsers: fail(f"parser abstraction contract missing: {phrase}")
+        if phrase not in parsers:
+            fail(f"parser abstraction contract missing: {phrase}")
     graph = (ENGINE / "repo_graph.py").read_text(encoding="utf-8")
     for phrase in ["GRAPH_SCHEMA_VERSION = 3", "DIRECT", "RESOLVED", "HEURISTIC", "DEPENDS_ON", "TESTS", "IMPORTS_SYMBOL", "cross_language", "bindings_by_path"]:
-        if phrase not in graph: fail(f"Polyglot graph contract missing: {phrase}")
+        if phrase not in graph:
+            fail(f"Polyglot graph contract missing: {phrase}")
     query = (ENGINE / "graph_query.py").read_text(encoding="utf-8")
     for phrase in ["def shortest_path(", "def bounded_expand(", "def dependents_for_nodes(", "def dependents_for_files(", "callers", "tests-for", "IMPORTS_SYMBOL"]:
-        if phrase not in query: fail(f"graph query contract missing: {phrase}")
+        if phrase not in query:
+            fail(f"graph query contract missing: {phrase}")
     impact = (ENGINE / "impact.py").read_text(encoding="utf-8")
     for phrase in ["changed_line_ranges", "changed_symbol_seeds", "symbol-structural", "cross_language_dependents", "test_plan"]:
-        if phrase not in impact: fail(f"impact intelligence contract missing: {phrase}")
+        if phrase not in impact:
+            fail(f"impact intelligence contract missing: {phrase}")
     tests = (ENGINE / "test_map.py").read_text(encoding="utf-8")
     for phrase in ["schema_version\": 3", "prioritized", "confidence", "cross_language_relationships"]:
-        if phrase not in tests: fail(f"test intelligence contract missing: {phrase}")
+        if phrase not in tests:
+            fail(f"test intelligence contract missing: {phrase}")
     compiler = (ENGINE / "task_compiler.py").read_text(encoding="utf-8")
     for depth in ["FAST", "NORMAL", "DEEP", "CRITICAL"]:
-        if depth not in compiler: fail(f"task compiler depth missing: {depth}")
-    if "init_project_brain(root, emit=False)" not in compiler: fail("normal task compilation must auto-initialize Project Brain")
-    if "apply_structural_escalation" not in compiler: fail("task compiler must consume structural risk")
+        if depth not in compiler:
+            fail(f"task compiler depth missing: {depth}")
+    if "init_project_brain(root, emit=False)" not in compiler:
+        fail("normal task compilation must auto-initialize Project Brain")
+    if "apply_structural_escalation" not in compiler:
+        fail("task compiler must consume structural risk")
+
+    slop = (ENGINE / "slop_guard.py").read_text(encoding="utf-8")
+    for phrase in [
+        "SCHEMA_VERSION = 1", "UNJUSTIFIED_SCOPE", "DUPLICATE_IMPLEMENTATION", "UNJUSTIFIED_DEPENDENCY",
+        "UNJUSTIFIED_PUBLIC_API", "protected_complexity", "underengineering_gate", "scoreable", "risk_score", "--strict",
+    ]:
+        if phrase not in slop:
+            fail(f"Anti-Slop contract missing: {phrase}")
 
     codex_skill = (ROOT / "plugins/codemium/skills/codemium/SKILL.md").read_text(encoding="utf-8")
-    for phrase in ["Project Brain persistence contract", "Do **not** require the user to run `$cm-init` first", "Persistence gate", "captured", "skipped by user constraint"]:
-        if phrase not in codex_skill: fail(f"Codex persistence behavior missing: {phrase}")
+    for phrase in [
+        "Project Brain persistence contract", "Do **not** require the user to run `$cm-init` first", "Persistence gate",
+        "captured", "skipped by user constraint", "Slop Guard", "Underengineering Counter-Gate",
+    ]:
+        if phrase not in codex_skill:
+            fail(f"Codex behavior missing: {phrase}")
 
-    result = subprocess.run([sys.executable, str(fixture)], cwd=ROOT, text=True, capture_output=True)
-    if result.returncode != 0:
-        sys.stdout.write(result.stdout); sys.stderr.write(result.stderr); fail("core fixture failed")
+    portable_skill = (ROOT / "skills/cm/SKILL.md").read_text(encoding="utf-8")
+    for phrase in ["minimum justified engineering", "Slop Guard", "Underengineering Counter-Gate"]:
+        if phrase not in portable_skill:
+            fail(f"portable Anti-Slop behavior missing: {phrase}")
+
+    run_fixture(fixture, "host-agnostic core")
+    run_fixture(slop_fixture, "v0.9 Slop Guard")
+
     print(json.dumps({
         "status": "pass", "version": version, "scope": "codemium-core",
-        "checked": ["engine syntax", "Project Brain persistence/evidence/freshness", "parser abstraction + deterministic fallback", "Structural Graph v3 + provenance", "incremental graph refresh", "symbol-aware impact/test mapping", "automatic Project Brain initialization/capture", "generic task/depth contract", "host-agnostic v0.8 core fixture"],
+        "checked": [
+            "engine syntax",
+            "Project Brain persistence/evidence/freshness",
+            "parser abstraction + deterministic fallback",
+            "Structural Graph v3 + provenance",
+            "incremental graph refresh",
+            "symbol-aware impact/test mapping",
+            "automatic Project Brain initialization/capture",
+            "generic task/depth contract",
+            "task-aware Slop Guard + coverage honesty",
+            "Underengineering Counter-Gate",
+            "host-agnostic core + Anti-Slop fixtures",
+        ],
     }, indent=2))
     print("PASS: Codemium core integrity")
 
 
-if __name__ == "__main__": main()
+if __name__ == "__main__":
+    main()

--- a/skills/cm/SKILL.md
+++ b/skills/cm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cm
-description: Use Codemium for software-engineering tasks that benefit from persistent project understanding, evidence-backed polyglot structural intelligence, bounded context, scoped changes, risk-aware testing, or explicit fast/deep/critical depth. Trigger for project-aware implementation, debugging, review, testing, refactoring, migration, security, cross-language JavaScript/TypeScript/TSX work, or when the user asks to reduce relearning/context waste without reducing engineering quality.
+description: Use Codemium for software-engineering tasks that benefit from persistent project understanding, evidence-backed polyglot structural intelligence, bounded context, scoped changes, risk-aware testing, v0.9 Anti-Slop / Slop Guard review, or explicit fast/deep/critical depth. Trigger for project-aware implementation, debugging, review, testing, refactoring, migration, security, cross-language JavaScript/TypeScript/TSX work, or when the user asks to reduce relearning/context waste without reducing engineering quality.
 argument-hint: "[fast|deep|critical] <coding task>"
 compatibility: "Claude Code, Gemini CLI, Cursor, OpenCode, and Agent Skills-compatible hosts"
 metadata:
@@ -9,7 +9,7 @@ metadata:
 
 # Codemium — portable Agent Skill
 
-Operate as a senior engineer who already knows this repository. Optimize for the **smallest justified engineering change** and minimum relearning, not minimum LOC.
+Operate as a senior engineer who already knows this repository. Optimize for the **minimum justified engineering surface** and minimum relearning, not minimum LOC.
 
 ## Resolve task and depth
 
@@ -85,7 +85,7 @@ Codemium ships a canonical Python engine. Use it when it reduces model work or s
 - Repository-root extension installs contain the canonical engine under `plugins/codemium/engine/`.
 - If the host exposes neither path reliably, preserve Codemium behavior using normal repository tools rather than guessing an extension path.
 
-Typical helper operations include Project Brain initialization/capture/freshness, repository Graph v3 refresh/query, parser health, graph-assisted Working Set ranking, symbol-aware impact, prioritized test mapping, cache checks, health, and telemetry. When available, `project_brain.py ... capture --entries <json-or-file>` is the preferred deterministic path for storing a small batch of durable facts.
+Typical helper operations include Project Brain initialization/capture/freshness, repository Graph v3 refresh/query, parser health, graph-assisted Working Set ranking, symbol-aware impact, prioritized test mapping, **Slop Guard**, cache checks, health, and telemetry. When available, `project_brain.py ... capture --entries <json-or-file>` is the preferred deterministic path for storing a small batch of durable facts.
 
 Do not run expensive helpers mechanically when the task is already obvious and local. Project Brain initialization/capture is different: it is lightweight state management and should happen when persistence is applicable.
 
@@ -103,10 +103,40 @@ Every changed hunk must trace to the requested task, a necessary dependency chan
 
 Minimal production code never means minimal tests. Verification follows behavior, failure modes, blast radius, and risk. Structurally related tests are candidates; confidence, actual source, and runtime/test evidence determine sufficiency.
 
+## Anti-Slop Intelligence — v0.9
+
+For normal source-changing work, run the task-aware **Slop Guard** near completion when `engine/slop_guard.py` is available. The goal is minimum justified engineering, not the smallest diff.
+
+Default Guard Mode is changed-surface-first:
+
+```text
+actual task diff
+→ changed symbols
+→ bounded graph evidence
+→ relevant source/tests
+```
+
+- Classify changed surfaces as `DIRECT`, `DEPENDENCY`, `CLEANUP`, or `TEST`. An internal `UNJUSTIFIED` surface must be justified with evidence or removed before completion.
+- Focus on slop introduced or worsened by the current task; do not convert unrelated historical debt into an unrequested cleanup project.
+- Prefer deterministic evidence, then Structural Graph v3 evidence, then evidence-backed reasoning for ambiguity.
+- Treat Slop Risk as informational. Honor coverage/scoreability and never fabricate a score when the helper cannot inspect enough of the changed source.
+- Resolve high-confidence blockers such as unjustified scope, duplicate implementation, unjustified dependency, or unjustified public API expansion before stopping.
+- Run the **Underengineering Counter-Gate** before accepting simplification. Preserve required authentication/authorization, validation/sanitization, rate limiting, transactions/locking/idempotency, retry behavior, data-integrity checks, migration/compatibility paths, security checks, and tests.
+- Only low-risk, high-confidence mechanical cleanup may be automatic. Abstraction/fallback/dependency/public-API/compatibility/test changes require review.
+- If cleanup changes source, re-run affected and impact-mapped tests, inspect the new actual diff, and run Slop Guard again. High-impact simplification requires a logically separate review pass.
+
+Typical portable invocation:
+
+```sh
+python engine/slop_guard.py --root . --json --write-state
+```
+
+Use `references/slop-policy.md` when a finding is ambiguous or cleanup could affect architecture/safety.
+
 ## Host reasoning
 
 Codemium engineering depth is portable. Vendor model/thinking controls remain host-owned unless a documented per-task mechanism exists and the host confirms the effective setting. Never claim a reasoning setting changed without confirmation.
 
 ## Completion
 
-Before stopping, classify Project Brain persistence as **captured**, **reused**, **none**, or **skipped by user constraint**. Revalidate any relevant `NEEDS_REVALIDATION` knowledge before materially relying on it. Then stop when requested behavior is satisfied, relevant verification passes, scope is clean, architecture/security constraints are preserved, persistence/freshness obligations are satisfied, and no material unexplained uncertainty remains. Continue only when you can name the unresolved risk or persistence obligation the next operation will reduce.
+Before stopping, classify Project Brain persistence as **captured**, **reused**, **none**, or **skipped by user constraint**. Revalidate any relevant `NEEDS_REVALIDATION` knowledge before materially relying on it. Then stop when requested behavior is satisfied, relevant verification passes, scope is clean, Slop Guard/justified-surface obligations are resolved, the Underengineering Counter-Gate is satisfied, architecture/security constraints are preserved, persistence/freshness obligations are satisfied, and no material unexplained uncertainty remains. Continue only when you can name the unresolved risk, unjustified surface, underengineering concern, or persistence obligation the next operation will reduce.


### PR DESCRIPTION
Closes #15.

## What this implements

- adds `engine/slop_guard.py` with task-aware diff scope, changed-surface classification, deterministic findings, Graph v3 structural evidence, coverage/scoreability, human + JSON reports, strict gating, and persisted report support;
- adds the Underengineering Counter-Gate so simplification does not silently remove security/data-integrity/compatibility complexity;
- adds `$cm-slop` plus the shared `slop-policy.md`;
- integrates Slop Guard into the primary Codex lifecycle and portable Agent Skill;
- adds a deterministic Anti-Slop fixture covering scope creep, dependency additions, duplicate implementation, single-use forwarding, debugger/type/comment residue, strict blocking, and protected-complexity removal;
- adds the v0.9 Anti-Slop benchmark protocol measuring both missed slop and over-simplification;
- extends `verify_core.py` so Anti-Slop becomes part of the core health contract.

## Design constraints preserved

- minimum justified engineering surface, not minimum LOC;
- changed-surface-first rather than repository-wide cleanup;
- deterministic evidence first, structural evidence second, reasoning only for ambiguity;
- risk score is informational and omitted when coverage is insufficient;
- no arbitrary FAST/NORMAL/DEEP slop budget;
- cleanup requires re-verification;
- protected complexity and tests are not blindly removed.

## Release handling

This PR intentionally keeps `VERSION` at `0.8.0` while the v0.9 implementation is validated in CI. Version/README/release metadata can be bumped to `0.9.0` after the implementation gate is green and blocking-rule behavior is reviewed.