### PR TITLE
v0.9: harden Slop Guard diff coverage and duplicate precision

### DIFF
--- a/plugins/codemium/engine/slop_guard.py
+++ b/plugins/codemium/engine/slop_guard.py
@@ -16,6 +16,7 @@ from common import git, read_json, state_root, write_json
 SCHEMA_VERSION = 1
 SOURCE_EXTENSIONS = {".py", ".js", ".jsx", ".ts", ".tsx"}
 TEST_MARKERS = ("/test/", "/tests/", "/__tests__/", ".test.", ".spec.")
+MAX_UNTRACKED_BYTES = 2_000_000
 BLOCKING_RULES = {
     "UNJUSTIFIED_SCOPE",
     "DUPLICATE_IMPLEMENTATION",
@@ -172,6 +173,36 @@ def parse_diff(text: str) -> dict[str, DiffFile]:
             old_line += 1
             new_line += 1
     return files
+
+
+def untracked_diff_files(root: Path) -> dict[str, DiffFile]:
+    """Represent safe, readable untracked files as added diff surfaces.
+
+    `git diff` does not include untracked files, but a newly generated source/config
+    file is exactly the kind of surface Slop Guard must not miss. Codemium's own
+    state remains excluded even when a repository has not yet ignored `.codemium/`.
+    """
+    raw = git(root, "ls-files", "--others", "--exclude-standard") or ""
+    out: dict[str, DiffFile] = {}
+    for rel in raw.splitlines():
+        path = rel.strip().replace("\\", "/")
+        if not path or path == ".codemium" or path.startswith(".codemium/"):
+            continue
+        full = root / path
+        try:
+            data = full.read_bytes()
+        except OSError:
+            continue
+        if len(data) > MAX_UNTRACKED_BYTES or b"\x00" in data:
+            continue
+        text = data.decode("utf-8", errors="ignore")
+        out[path] = DiffFile(
+            path=path,
+            old_path=None,
+            status="added",
+            added=[(line_no, line) for line_no, line in enumerate(text.splitlines(), start=1)],
+        )
+    return out
 
 
 def _task_scope(task: dict) -> list[str]:
@@ -333,15 +364,22 @@ def detect_structural_findings(root: Path, graph: dict, idx: dict[str, Any], dif
             sid = sym.get("id")
             label = str(sym.get("label") or "")
             subtype = str(sym.get("subtype") or "").lower()
+            qualified = str(sym.get("qualified_name") or label)
             inbound = int(idx["inbound"].get(sid, 0))
             peers = [x for x in idx["symbols_by_label"].get(label, []) if x.get("id") != sid and x.get("path") != path and str(x.get("subtype") or "").lower() == subtype]
-            if label and peers:
-                findings.append(Finding(
-                    "DUPLICATE_IMPLEMENTATION", path, "MAJOR", 0.86, "STRUCTURAL", "REVIEW_REQUIRED",
-                    "a newly changed symbol shares the same repository-level symbol name/type with an existing implementation; inspect reuse before accepting duplication",
-                    line=sym.get("line_start"), symbol=label,
-                    evidence={"existing": [{"path": p.get("path"), "symbol": p.get("qualified_name") or p.get("label")} for p in peers[:5]], "inbound": inbound},
-                ))
+            # Same-named methods/classes are routine across unrelated types and are too
+            # noisy for a blocking duplicate signal. Reserve the high-confidence gate
+            # for top-level functions, then require source review before consolidation.
+            is_top_level_function = subtype == "function" and "." not in qualified
+            if label and peers and is_top_level_function:
+                function_peers = [p for p in peers if "." not in str(p.get("qualified_name") or p.get("label") or "")]
+                if function_peers:
+                    findings.append(Finding(
+                        "DUPLICATE_IMPLEMENTATION", path, "MAJOR", 0.9, "STRUCTURAL", "REVIEW_REQUIRED",
+                        "a newly changed top-level function shares the same repository-level function name with an existing implementation; inspect reuse before accepting duplication",
+                        line=sym.get("line_start"), symbol=label,
+                        evidence={"existing": [{"path": p.get("path"), "symbol": p.get("qualified_name") or p.get("label")} for p in function_peers[:5]], "inbound": inbound},
+                    ))
             if subtype in {"function", "method"} and label in py_forwarders and inbound <= 1:
                 findings.append(Finding(
                     "SINGLE_USE_FORWARDER", path, "MINOR", 0.89, "STRUCTURAL", "REVIEW_REQUIRED",
@@ -468,6 +506,9 @@ def analyze(root: Path, base: str | None = None, head: str | None = None) -> dic
     graph = read_json(state / "repository/graph.json", {})
     scope = resolve_diff_scope(root, base, head, task)
     diff_files = parse_diff(get_diff(root, scope))
+    if scope["head"] == "WORKTREE":
+        for path, diff_file in untracked_diff_files(root).items():
+            diff_files.setdefault(path, diff_file)
     classifications = {path: classify_surface(path, task, graph) for path in sorted(diff_files)}
     idx = graph_indexes(graph)
     findings = []

--- a/plugins/codemium/tests/test_slop_guard.py
+++ b/plugins/codemium/tests/test_slop_guard.py
@@ -33,7 +33,8 @@ def commit(root: Path, message: str = "initial") -> None:
 
 def main() -> None:
     # Introduced-slop fixture: task scope, line-level smells, dependency delta,
-    # duplicate implementation, and single-use forwarder must all be evidence-backed.
+    # duplicate implementation, single-use forwarder, and untracked source files
+    # must all be visible to the gate.
     with tempfile.TemporaryDirectory() as td:
         root = Path(td)
         (root / "src").mkdir()
@@ -59,6 +60,7 @@ def main() -> None:
             encoding="utf-8",
         )
         (root / "src/unrelated.py").write_text("def untouched():\n    return 2\n", encoding="utf-8")
+        (root / "src/new_helper.py").write_text("def new_helper():\n    return True\n", encoding="utf-8")
         (root / "package.json").write_text(
             json.dumps({"dependencies": {"left-pad": "1.3.0"}}, indent=2) + "\n", encoding="utf-8"
         )
@@ -102,7 +104,9 @@ def main() -> None:
         ]:
             assert rule in rules, (rule, rules)
         assert report["status"] == "fail", report
-        assert report["surfaces"]["unjustified"] == 1
+        assert report["changed_files"] == 4, report["surface_classification"]
+        assert report["surfaces"]["unjustified"] == 2
+        assert report["surface_classification"]["src/new_helper.py"]["class"] == "UNJUSTIFIED"
         assert report["scoreable"] is True and report["risk_score"] is not None
         assert report["underengineering_gate"]["status"] == "pass"
 
@@ -151,7 +155,46 @@ def main() -> None:
         assert report["status"] == "review", report
         assert report["risk_score"] is None and report["scoreable"] is False
 
-    print("PASS: Codemium v0.9 Slop Guard deterministic + structural + underengineering fixture")
+    # Duplicate detection must stay high precision. Same-named methods on unrelated
+    # classes are common and must not trigger the blocking duplicate rule.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        (root / "src").mkdir()
+        init_repo(root)
+        (root / "src/a.py").write_text(
+            "class A:\n    def save(self, value):\n        return value\n",
+            encoding="utf-8",
+        )
+        (root / "src/b.py").write_text("class B:\n    pass\n", encoding="utf-8")
+        commit(root)
+        (root / "src/b.py").write_text(
+            "class B:\n    def save(self, value):\n        return value\n",
+            encoding="utf-8",
+        )
+
+        state = root / ".codemium"
+        (state / "tasks").mkdir(parents=True)
+        (state / "repository").mkdir()
+        (state / "tasks/active.json").write_text(json.dumps({"working_set": ["src/b.py"]}), encoding="utf-8")
+        graph = {
+            "files": [
+                {"path": "src/a.py", "language": "python", "is_test": False, "parser": "python-ast", "capabilities": {"symbols": True}},
+                {"path": "src/b.py", "language": "python", "is_test": False, "parser": "python-ast", "capabilities": {"symbols": True}},
+            ],
+            "nodes": [
+                {"id": "s:a:save", "type": "SYMBOL", "subtype": "method", "label": "save", "qualified_name": "A.save", "path": "src/a.py", "line_start": 2, "line_end": 3},
+                {"id": "s:b:save", "type": "SYMBOL", "subtype": "method", "label": "save", "qualified_name": "B.save", "path": "src/b.py", "line_start": 2, "line_end": 3},
+            ],
+            "edges": [],
+        }
+        (state / "repository/graph.json").write_text(json.dumps(graph), encoding="utf-8")
+
+        p = run(sys.executable, ENGINE / "slop_guard.py", "--root", root, "--base", "HEAD", "--json")
+        report = json.loads(p.stdout)
+        duplicate_methods = [f for f in report["findings"] if f["rule"] == "DUPLICATE_IMPLEMENTATION" and f.get("symbol") == "save"]
+        assert duplicate_methods == [], duplicate_methods
+
+    print("PASS: Codemium v0.9 Slop Guard tracked/untracked + structural + underengineering fixture")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up hardening for the v0.9 Anti-Slop implementation.

## Fixes

- include safe UTF-8 untracked worktree files in Slop Guard analysis; `git diff` alone misses newly generated files, which can otherwise bypass changed-surface classification;
- explicitly exclude `.codemium/` state from untracked-file analysis;
- cap untracked file reads and skip binary files;
- narrow high-confidence `DUPLICATE_IMPLEMENTATION` blocking signals to same-named top-level functions instead of common same-named class methods/classes;
- add regression coverage proving an untracked source file is classified and same-named methods do not trigger the duplicate blocker.

This remains release hardening only; no benchmark-performance claims or version bump are included.