### PR TITLE
v0.9: complete Anti-Slop release gates

### DIFF
--- a/benchmarks/V09_ANTISLOP_BENCHMARK.md
+++ b/benchmarks/V09_ANTISLOP_BENCHMARK.md
@@ -79,7 +79,8 @@ Record at minimum:
 - new public API surfaces;
 - duplicate implementations introduced;
 - unnecessary abstractions introduced;
-- Slop Guard findings by rule/severity/confidence;
+- Slop Guard findings by rule/severity/confidence/provenance;
+- adjudications and their source/task evidence;
 - false-positive findings;
 - necessary complexity incorrectly removed or blocked;
 - Slop Guard wall-clock overhead;
@@ -127,19 +128,51 @@ Protection examples should include legitimate:
 
 A false-positive blocker is considered more harmful than a missed cosmetic finding.
 
-## Deterministic fixture
+## Deterministic engine fixture
 
 `plugins/codemium/tests/test_slop_guard.py` is the release-regression fixture for the engine. It proves:
 
-- task-scope violations are detected;
+- task-scope violations are detected, including safe untracked files;
+- caused cleanup surfaces can be classified explicitly as `CLEANUP`;
 - added debugger/type/comment signals are reported;
 - package dependency deltas are detected;
 - Graph v3 evidence can identify a duplicate implementation and single-use forwarder;
-- strict mode fails on high-confidence blocking findings;
-- protected-complexity removal triggers the Underengineering Counter-Gate;
+- finding provenance distinguishes `introduced`, `worsened`, `pre_existing`, and `unknown` states;
+- pre-existing structural debt does not become a blocker merely because its file was touched;
+- evidence-backed `JUSTIFIED` adjudication can resolve a matched blocker without weakening the global rule;
+- strict mode fails on unresolved high-confidence blocking findings;
+- protected-complexity removal across auth/validation/rate-limit/transaction/locking/idempotency/retry/migration/compatibility/integrity/security signals triggers the Underengineering Counter-Gate;
 - no risk score is fabricated when scoreable source coverage is insufficient.
 
 This fixture validates engine mechanics. It is **not** a substitute for measured multi-arm coding-agent runs.
+
+## Release blocking-semantics calibration
+
+`benchmarks/v09-blocking-calibration.json` is a small labeled release corpus for the decision semantics of the gate. `benchmarks/calibrate_v09_blocking.py` verifies that the implementation preserves the intended outcomes for:
+
+- introduced high-confidence blockers;
+- worsened blockers;
+- pre-existing debt;
+- evidence-backed justified blockers;
+- unknown/ambiguous major findings;
+- lower-confidence blocker candidates;
+- minor non-blocking noise;
+- protected-complexity removal;
+- clean diffs.
+
+Run:
+
+```sh
+python benchmarks/calibrate_v09_blocking.py
+```
+
+This calibration is part of core CI. It is **not a competitive benchmark**, and its pass count must not be presented as an agent-quality, token-efficiency, or performance claim. Its only purpose is to prevent accidental changes in blocker precision/safety policy while v0.9 is released.
+
+## Measured multi-arm benchmark status
+
+The benchmark protocol is ready for measured `baseline` / `codemium_v08` / `codemium_v09_guard` runs, but release-blocking engine calibration and competitive measurement are deliberately separate.
+
+A v0.9 release may state that Anti-Slop Intelligence and its calibrated safety gates exist after release verification passes. It must **not** publish numeric competitive Anti-Slop improvement claims until representative multi-arm runs are performed and the raw evidence is retained.
 
 ## Publication gate
 

--- a/benchmarks/calibrate_v09_blocking.py
+++ b/benchmarks/calibrate_v09_blocking.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGINE = ROOT / "plugins/codemium/engine"
+sys.path.insert(0, str(ENGINE))
+
+from slop_guard import Finding, verdict  # noqa: E402
+
+
+def main() -> None:
+    corpus_path = ROOT / "benchmarks/v09-blocking-calibration.json"
+    corpus = json.loads(corpus_path.read_text(encoding="utf-8"))
+    cases = corpus.get("cases", [])
+    failures = []
+    results = []
+    for case in cases:
+        findings = []
+        for raw in case.get("findings", []):
+            adjudication = None
+            if raw.get("justified"):
+                adjudication = {
+                    "status": "accepted",
+                    "decision": "JUSTIFIED",
+                    "reason": "Calibration fixture provides evidence-backed justification.",
+                    "evidence": [{"kind": "task", "detail": "calibration fixture"}],
+                }
+            findings.append(Finding(
+                rule=raw["rule"],
+                path=raw["path"],
+                severity=raw["severity"],
+                confidence=float(raw["confidence"]),
+                evidence_class="DETERMINISTIC",
+                autofix="REVIEW_REQUIRED",
+                reason="calibration fixture",
+                provenance=raw["provenance"],
+                adjudication=adjudication,
+            ))
+        removed = [{"path": "src/safety.py", "line": 1, "text": "transaction"}] if case.get("protected_removal") else []
+        protected = {
+            "added": [],
+            "removed": removed,
+            "underengineering_gate": {
+                "status": "review_required" if removed else "pass",
+                "reason": "calibration protected removal" if removed else "no protected removal",
+            },
+        }
+        actual = verdict(findings, protected)
+        expected = case["expected_status"]
+        results.append({"id": case["id"], "expected": expected, "actual": actual, "pass": actual == expected})
+        if actual != expected:
+            failures.append(case["id"])
+
+    output = {
+        "schema_version": 1,
+        "status": "pass" if not failures else "fail",
+        "cases": len(cases),
+        "failed": failures,
+        "results": results,
+        "note": "Blocking calibration only; not a competitive performance or efficiency claim."
+    }
+    print(json.dumps(output, indent=2))
+    if failures:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/v09-blocking-calibration.json
+++ b/benchmarks/v09-blocking-calibration.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": 1,
+  "purpose": "Release calibration corpus for v0.9 blocking semantics; not a competitive performance benchmark.",
+  "cases": [
+    {
+      "id": "introduced_scope_blocks",
+      "expected_status": "fail",
+      "findings": [{"rule":"UNJUSTIFIED_SCOPE","path":"src/unrelated.py","severity":"MAJOR","confidence":0.99,"provenance":"introduced"}]
+    },
+    {
+      "id": "worsened_duplicate_blocks",
+      "expected_status": "fail",
+      "findings": [{"rule":"DUPLICATE_IMPLEMENTATION","path":"src/service.py","severity":"MAJOR","confidence":0.90,"provenance":"worsened"}]
+    },
+    {
+      "id": "introduced_dependency_blocks",
+      "expected_status": "fail",
+      "findings": [{"rule":"UNJUSTIFIED_DEPENDENCY","path":"package.json","severity":"MAJOR","confidence":0.98,"provenance":"introduced"}]
+    },
+    {
+      "id": "pre_existing_duplicate_does_not_block",
+      "expected_status": "pass",
+      "findings": [{"rule":"DUPLICATE_IMPLEMENTATION","path":"src/legacy.py","severity":"MAJOR","confidence":0.90,"provenance":"pre_existing"}]
+    },
+    {
+      "id": "justified_blocker_does_not_block",
+      "expected_status": "pass",
+      "findings": [{"rule":"DUPLICATE_IMPLEMENTATION","path":"src/adapter.py","severity":"MAJOR","confidence":0.90,"provenance":"introduced","justified":true}]
+    },
+    {
+      "id": "unknown_major_requires_review",
+      "expected_status": "review",
+      "findings": [{"rule":"SPECULATIVE_FALLBACK","path":"src/client.py","severity":"MAJOR","confidence":0.76,"provenance":"unknown"}]
+    },
+    {
+      "id": "low_confidence_blocker_requires_review_not_fail",
+      "expected_status": "review",
+      "findings": [{"rule":"UNJUSTIFIED_PUBLIC_API","path":"src/api.ts","severity":"MAJOR","confidence":0.72,"provenance":"introduced"}]
+    },
+    {
+      "id": "minor_comment_is_nonblocking",
+      "expected_status": "pass",
+      "findings": [{"rule":"NARRATIVE_COMMENT","path":"src/math.py","severity":"MINOR","confidence":0.66,"provenance":"introduced"}]
+    },
+    {
+      "id": "protected_removal_requires_review",
+      "expected_status": "review",
+      "protected_removal": true,
+      "findings": []
+    },
+    {
+      "id": "clean_diff_passes",
+      "expected_status": "pass",
+      "findings": []
+    }
+  ]
+}

--- a/plugins/codemium/engine/slop_guard.py
+++ b/plugins/codemium/engine/slop_guard.py
@@ -14,9 +14,11 @@ from typing import Any
 from common import git, read_json, state_root, write_json
 
 SCHEMA_VERSION = 1
+ADJUDICATION_SCHEMA_VERSION = 1
 SOURCE_EXTENSIONS = {".py", ".js", ".jsx", ".ts", ".tsx"}
 TEST_MARKERS = ("/test/", "/tests/", "/__tests__/", ".test.", ".spec.")
 MAX_UNTRACKED_BYTES = 2_000_000
+PROVENANCE_VALUES = {"introduced", "worsened", "pre_existing", "unknown"}
 BLOCKING_RULES = {
     "UNJUSTIFIED_SCOPE",
     "DUPLICATE_IMPLEMENTATION",
@@ -25,21 +27,26 @@ BLOCKING_RULES = {
 }
 SEVERITY_WEIGHT = {"BLOCKER": 25, "MAJOR": 12, "MINOR": 4, "INFO": 1}
 PROTECTED_RE = re.compile(
-    r"\b(auth(?:entication|orization)?|permission|role|validat(?:e|ion)|saniti[sz](?:e|ation)|"
+    r"(?<![A-Za-z0-9])(auth(?:enticate|entication)?|authoriz(?:e|ation)|permission|role|validat(?:e|ion)|saniti[sz](?:e|ation)|"
     r"rate.?limit|transaction|rollback|lock(?:ing)?|idempoten(?:t|cy)|retry|migration|compatib(?:ility|le)|"
-    r"integrity|csrf|xss|encrypt(?:ion|ed)?|decrypt(?:ion|ed)?|signature|nonce|secret|token)\b",
+    r"integrity|csrf|xss|encrypt(?:ion|ed)?|decrypt(?:ion|ed)?|signature|nonce|secret|token)(?=[^A-Za-z0-9]|$)",
     re.I,
 )
 DEBUG_STRONG_RE = re.compile(r"\b(?:debugger\s*;?|breakpoint\s*\(|pdb\.set_trace\s*\(|console\.(?:debug|trace)\s*\()")
 DEBUG_WEAK_RE = re.compile(r"\b(?:console\.log\s*\(|print\s*\()")
 TYPE_ESCAPE_RE = re.compile(r"(?:#\s*type:\s*ignore|@ts-ignore|@ts-nocheck|\bas\s+any\b|:\s*any\b)")
 PUBLIC_API_RE = re.compile(
-    r"^\s*(?:export\s+(?:default\s+)?(?:async\s+)?(?:function|class|const|let|var|interface|type|enum)\b|__all__\s*=)")
+    r"^\s*(?:export\s+(?:default\s+)?(?:async\s+)?(?:function|class|const|let|var|interface|type|enum)\b|__all__\s*=)"
+)
 BROAD_EXCEPTION_RE = re.compile(r"\b(?:except\s+(?:Exception|BaseException)\b|catch\s*\([^)]*\)\s*\{?)")
 NARRATIVE_COMMENT_RE = re.compile(
     r"^\s*(?:#|//)\s*(?:increment|decrement|set|return|check|initialize|initialise|create|call|loop|iterate|"
     r"assign|update|delete|remove|add|convert|parse|format|sort|filter|map|open|close|read|write)\b",
     re.I,
+)
+JS_TS_TOP_LEVEL_RE = re.compile(
+    r"^\s*(?:export\s+(?:default\s+)?)?(?:async\s+)?(?:function|class|interface|type|enum)\s+([A-Za-z_$][\w$]*)",
+    re.M,
 )
 
 
@@ -61,16 +68,19 @@ class Finding:
     evidence_class: str
     autofix: str
     reason: str
-    introduced: str = "introduced"
+    provenance: str = "unknown"
     line: int | None = None
     symbol: str | None = None
     evidence: dict[str, Any] = field(default_factory=dict)
+    adjudication: dict[str, Any] | None = None
 
     def as_dict(self) -> dict[str, Any]:
+        provenance = self.provenance if self.provenance in PROVENANCE_VALUES else "unknown"
         out = {
             "rule": self.rule,
             "path": self.path,
-            "introduced": self.introduced,
+            "provenance": provenance,
+            "introduced": provenance,
             "severity": self.severity,
             "confidence": round(self.confidence, 2),
             "evidence_class": self.evidence_class,
@@ -82,6 +92,8 @@ class Finding:
             out["line"] = self.line
         if self.symbol:
             out["symbol"] = self.symbol
+        if self.adjudication:
+            out["adjudication"] = self.adjudication
         return out
 
 
@@ -176,12 +188,6 @@ def parse_diff(text: str) -> dict[str, DiffFile]:
 
 
 def untracked_diff_files(root: Path) -> dict[str, DiffFile]:
-    """Represent safe, readable untracked files as added diff surfaces.
-
-    `git diff` does not include untracked files, but a newly generated source/config
-    file is exactly the kind of surface Slop Guard must not miss. Codemium's own
-    state remains excluded even when a repository has not yet ignored `.codemium/`.
-    """
     raw = git(root, "ls-files", "--others", "--exclude-standard") or ""
     out: dict[str, DiffFile] = {}
     for rel in raw.splitlines():
@@ -205,8 +211,20 @@ def untracked_diff_files(root: Path) -> dict[str, DiffFile]:
     return out
 
 
+def _cleanup_scope(task: dict) -> list[str]:
+    patterns = list(task.get("cleanup_set") or [])
+    for path, evidence in (task.get("working_set_evidence") or {}).items():
+        if any(str(item.get("kind") or item.get("class") or "").lower() == "cleanup" for item in evidence if isinstance(item, dict)):
+            if path not in patterns:
+                patterns.append(path)
+    return patterns
+
+
 def _task_scope(task: dict) -> list[str]:
     patterns = list(task.get("working_set") or [])
+    for p in _cleanup_scope(task):
+        if p not in patterns:
+            patterns.append(p)
     for p in (task.get("working_set_evidence") or {}).keys():
         if p not in patterns:
             patterns.append(p)
@@ -217,11 +235,14 @@ def classify_surface(path: str, task: dict, graph: dict) -> dict[str, Any]:
     graph_file = next((f for f in graph.get("files", []) if f.get("path") == path), {})
     if graph_file.get("is_test") or _is_test_path(path):
         return {"class": "TEST", "reason": "verification/test surface"}
+    cleanup = _cleanup_scope(task)
+    if cleanup and _allowed(path, cleanup):
+        return {"class": "CLEANUP", "reason": "explicitly recorded cleanup caused by the task change"}
     patterns = _task_scope(task)
     if patterns and not _allowed(path, patterns):
         return {"class": "UNJUSTIFIED", "reason": "changed path is outside the active task working set"}
     evidence = (task.get("working_set_evidence") or {}).get(path, [])
-    graph_reasons = [x for x in evidence if x.get("kind") == "graph"]
+    graph_reasons = [x for x in evidence if isinstance(x, dict) and x.get("kind") == "graph"]
     if graph_reasons:
         best = min(graph_reasons, key=lambda x: int(x.get("distance", 99)))
         distance = int(best.get("distance", 99))
@@ -271,21 +292,61 @@ def _intersects_added(symbol: dict, diff_file: DiffFile) -> bool:
     return any(start <= line <= end for line, _ in diff_file.added)
 
 
+def _load_text_at_ref(root: Path, ref: str, path: str) -> str | None:
+    return git(root, "show", f"{ref}:{path}")
+
+
+def _python_symbol_state(text: str) -> tuple[set[str], set[str]]:
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return set(), set()
+    symbols: set[str] = set()
+    forwarders: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            symbols.add(node.name)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and len(node.body) == 1:
+            stmt = node.body[0]
+            if isinstance(stmt, ast.Return) and isinstance(stmt.value, ast.Call):
+                forwarders.add(node.name)
+            elif isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+                forwarders.add(node.name)
+    return symbols, forwarders
+
+
+def _symbol_state(path: str, text: str | None) -> tuple[set[str], set[str]]:
+    if text is None:
+        return set(), set()
+    suffix = Path(path).suffix.lower()
+    if suffix == ".py":
+        return _python_symbol_state(text)
+    if suffix in {".js", ".jsx", ".ts", ".tsx"}:
+        return set(JS_TS_TOP_LEVEL_RE.findall(text)), set()
+    return set(), set()
+
+
 def _python_forwarders(path: Path) -> set[str]:
     try:
-        tree = ast.parse(path.read_text(encoding="utf-8"))
-    except (OSError, SyntaxError, UnicodeDecodeError):
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
         return set()
-    out: set[str] = set()
-    for node in ast.walk(tree):
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) or len(node.body) != 1:
-            continue
-        stmt = node.body[0]
-        if isinstance(stmt, ast.Return) and isinstance(stmt.value, ast.Call):
-            out.add(node.name)
-        elif isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
-            out.add(node.name)
-    return out
+    return _python_symbol_state(text)[1]
+
+
+def _structural_provenance(root: Path, scope: dict[str, str], df: DiffFile, label: str, rule: str) -> str:
+    if df.status == "added":
+        return "introduced"
+    old_path = df.old_path or df.path
+    base_text = _load_text_at_ref(root, scope["base"], old_path)
+    if base_text is None:
+        return "unknown"
+    symbols, forwarders = _symbol_state(old_path, base_text)
+    if label not in symbols:
+        return "introduced"
+    if rule == "SINGLE_USE_FORWARDER" and label not in forwarders:
+        return "worsened"
+    return "pre_existing"
 
 
 def detect_line_findings(diff_files: dict[str, DiffFile]) -> list[Finding]:
@@ -294,24 +355,24 @@ def detect_line_findings(diff_files: dict[str, DiffFile]) -> list[Finding]:
         test_path = _is_test_path(path)
         for line, text in df.added:
             if DEBUG_STRONG_RE.search(text):
-                findings.append(Finding("DEBUG_RESIDUE", path, "MAJOR", 0.99, "DETERMINISTIC", "SAFE_MECHANICAL", "debugger/breakpoint residue was added", line=line, evidence={"line": text.strip()}))
+                findings.append(Finding("DEBUG_RESIDUE", path, "MAJOR", 0.99, "DETERMINISTIC", "SAFE_MECHANICAL", "debugger/breakpoint residue was added", "introduced", line=line, evidence={"line": text.strip()}))
             elif DEBUG_WEAK_RE.search(text) and not test_path:
-                findings.append(Finding("DEBUG_RESIDUE", path, "MINOR", 0.78, "DETERMINISTIC", "REVIEW_REQUIRED", "console/print output was added to production code", line=line, evidence={"line": text.strip()}))
+                findings.append(Finding("DEBUG_RESIDUE", path, "MINOR", 0.78, "DETERMINISTIC", "REVIEW_REQUIRED", "console/print output was added to production code", "introduced", line=line, evidence={"line": text.strip()}))
             if TYPE_ESCAPE_RE.search(text) and not test_path:
-                findings.append(Finding("UNJUSTIFIED_TYPE_ESCAPE", path, "MAJOR", 0.91, "DETERMINISTIC", "REVIEW_REQUIRED", "type-system escape hatch was added", line=line, evidence={"line": text.strip()}))
+                findings.append(Finding("UNJUSTIFIED_TYPE_ESCAPE", path, "MAJOR", 0.91, "DETERMINISTIC", "REVIEW_REQUIRED", "type-system escape hatch was added", "introduced", line=line, evidence={"line": text.strip()}))
             if NARRATIVE_COMMENT_RE.search(text) and len(text.strip()) <= 100 and not test_path:
-                findings.append(Finding("NARRATIVE_COMMENT", path, "MINOR", 0.66, "DETERMINISTIC", "SAFE_MECHANICAL", "comment appears to narrate an obvious operation rather than record rationale", line=line, evidence={"line": text.strip()}))
+                findings.append(Finding("NARRATIVE_COMMENT", path, "MINOR", 0.66, "DETERMINISTIC", "SAFE_MECHANICAL", "comment appears to narrate an obvious operation rather than record rationale", "introduced", line=line, evidence={"line": text.strip()}))
             if PUBLIC_API_RE.search(text) and not test_path:
-                findings.append(Finding("UNJUSTIFIED_PUBLIC_API", path, "MINOR", 0.72, "DETERMINISTIC", "REVIEW_REQUIRED", "public/exported API surface was added and requires task-level justification", line=line, evidence={"line": text.strip()}))
+                findings.append(Finding("UNJUSTIFIED_PUBLIC_API", path, "MINOR", 0.72, "DETERMINISTIC", "REVIEW_REQUIRED", "public/exported API surface was added and requires task-level justification", "introduced", line=line, evidence={"line": text.strip()}))
             if BROAD_EXCEPTION_RE.search(text) and not test_path:
                 nearby = [t for ln, t in df.added if line < ln <= line + 5]
                 if any(re.search(r"\b(return|continue|pass|default|fallback)\b", t, re.I) for t in nearby):
-                    findings.append(Finding("SPECULATIVE_FALLBACK", path, "MAJOR", 0.76, "DETERMINISTIC", "REVIEW_REQUIRED", "broad exception path with fallback-like behavior was added", line=line, evidence={"line": text.strip(), "nearby_added": [x.strip() for x in nearby[:5]]}))
+                    findings.append(Finding("SPECULATIVE_FALLBACK", path, "MAJOR", 0.76, "DETERMINISTIC", "REVIEW_REQUIRED", "broad exception path with fallback-like behavior was added", "introduced", line=line, evidence={"line": text.strip(), "nearby_added": [x.strip() for x in nearby[:5]]}))
     return findings
 
 
 def _load_json_at_ref(root: Path, ref: str, path: str) -> dict:
-    raw = git(root, "show", f"{ref}:{path}")
+    raw = _load_text_at_ref(root, ref, path)
     if raw is None:
         return {}
     try:
@@ -336,7 +397,7 @@ def detect_dependency_findings(root: Path, scope: dict[str, str], diff_files: di
                 findings.append(Finding(
                     "UNJUSTIFIED_DEPENDENCY", "package.json", "MAJOR", 0.98, "DETERMINISTIC", "REVIEW_REQUIRED",
                     f"new {section} entry requires evidence that project/stdlib/native capability cannot satisfy the task",
-                    evidence={"dependency": name, "version": new.get(name), "section": section},
+                    "introduced", evidence={"dependency": name, "version": new.get(name), "section": section},
                 ))
     for path, df in diff_files.items():
         name = Path(path).name.lower()
@@ -344,16 +405,16 @@ def detect_dependency_findings(root: Path, scope: dict[str, str], diff_files: di
             for line, text in df.added:
                 dep = text.strip()
                 if dep and not dep.startswith(("#", "-", "git+", "http://", "https://")):
-                    findings.append(Finding("UNJUSTIFIED_DEPENDENCY", path, "MAJOR", 0.92, "DETERMINISTIC", "REVIEW_REQUIRED", "new Python dependency entry requires necessity evidence", line=line, evidence={"dependency": dep}))
+                    findings.append(Finding("UNJUSTIFIED_DEPENDENCY", path, "MAJOR", 0.92, "DETERMINISTIC", "REVIEW_REQUIRED", "new Python dependency entry requires necessity evidence", "introduced", line=line, evidence={"dependency": dep}))
         elif name in {"go.mod", "cargo.toml", "gemfile"}:
             for line, text in df.added:
                 stripped = text.strip()
                 if stripped and not stripped.startswith(("#", "//", "[")):
-                    findings.append(Finding("UNJUSTIFIED_DEPENDENCY", path, "MINOR", 0.68, "DETERMINISTIC", "REVIEW_REQUIRED", "dependency-manifest addition requires review", line=line, evidence={"line": stripped}))
+                    findings.append(Finding("UNJUSTIFIED_DEPENDENCY", path, "MINOR", 0.68, "DETERMINISTIC", "REVIEW_REQUIRED", "dependency-manifest addition requires review", "introduced", line=line, evidence={"line": stripped}))
     return findings
 
 
-def detect_structural_findings(root: Path, graph: dict, idx: dict[str, Any], diff_files: dict[str, DiffFile]) -> list[Finding]:
+def detect_structural_findings(root: Path, scope: dict[str, str], graph: dict, idx: dict[str, Any], diff_files: dict[str, DiffFile]) -> list[Finding]:
     findings: list[Finding] = []
     for path, df in diff_files.items():
         symbols = [s for s in idx["symbols_by_path"].get(path, []) if _intersects_added(s, df)]
@@ -367,9 +428,6 @@ def detect_structural_findings(root: Path, graph: dict, idx: dict[str, Any], dif
             qualified = str(sym.get("qualified_name") or label)
             inbound = int(idx["inbound"].get(sid, 0))
             peers = [x for x in idx["symbols_by_label"].get(label, []) if x.get("id") != sid and x.get("path") != path and str(x.get("subtype") or "").lower() == subtype]
-            # Same-named methods/classes are routine across unrelated types and are too
-            # noisy for a blocking duplicate signal. Reserve the high-confidence gate
-            # for top-level functions, then require source review before consolidation.
             is_top_level_function = subtype == "function" and "." not in qualified
             if label and peers and is_top_level_function:
                 function_peers = [p for p in peers if "." not in str(p.get("qualified_name") or p.get("label") or "")]
@@ -377,6 +435,7 @@ def detect_structural_findings(root: Path, graph: dict, idx: dict[str, Any], dif
                     findings.append(Finding(
                         "DUPLICATE_IMPLEMENTATION", path, "MAJOR", 0.9, "STRUCTURAL", "REVIEW_REQUIRED",
                         "a newly changed top-level function shares the same repository-level function name with an existing implementation; inspect reuse before accepting duplication",
+                        _structural_provenance(root, scope, df, label, "DUPLICATE_IMPLEMENTATION"),
                         line=sym.get("line_start"), symbol=label,
                         evidence={"existing": [{"path": p.get("path"), "symbol": p.get("qualified_name") or p.get("label")} for p in function_peers[:5]], "inbound": inbound},
                     ))
@@ -384,18 +443,21 @@ def detect_structural_findings(root: Path, graph: dict, idx: dict[str, Any], dif
                 findings.append(Finding(
                     "SINGLE_USE_FORWARDER", path, "MINOR", 0.89, "STRUCTURAL", "REVIEW_REQUIRED",
                     "single-statement forwarding function has at most one inbound structural consumer",
+                    _structural_provenance(root, scope, df, label, "SINGLE_USE_FORWARDER"),
                     line=sym.get("line_start"), symbol=label, evidence={"inbound_consumers": inbound},
                 ))
             if inbound == 0 and subtype in {"function", "method", "class", "interface"} and not label.startswith("test"):
                 findings.append(Finding(
                     "NEW_DEAD_CODE", path, "MINOR", 0.64, "STRUCTURAL", "REVIEW_REQUIRED",
-                    "newly changed symbol has no inbound structural consumer; entrypoint/reflection use must be ruled out before removal",
+                    "changed symbol has no inbound structural consumer; entrypoint/reflection use must be ruled out before removal",
+                    _structural_provenance(root, scope, df, label, "NEW_DEAD_CODE"),
                     line=sym.get("line_start"), symbol=label, evidence={"inbound_consumers": 0},
                 ))
             if subtype in {"class", "interface"} and inbound <= 1 and int(idx["implementations"].get(sid, 0)) <= 1:
                 findings.append(Finding(
                     "GRATUITOUS_ABSTRACTION", path, "MINOR", 0.67, "STRUCTURAL", "REVIEW_REQUIRED",
-                    "new abstraction has limited structural consumers/implementations and needs architecture justification",
+                    "changed abstraction has limited structural consumers/implementations and needs architecture justification",
+                    _structural_provenance(root, scope, df, label, "GRATUITOUS_ABSTRACTION"),
                     line=sym.get("line_start"), symbol=label,
                     evidence={"inbound_consumers": inbound, "implementations": int(idx["implementations"].get(sid, 0))},
                 ))
@@ -406,7 +468,7 @@ def detect_structural_findings(root: Path, graph: dict, idx: dict[str, Any], dif
                 findings.append(Finding(
                     "UNNECESSARY_FILE", path, "MINOR", 0.7, "STRUCTURAL", "REVIEW_REQUIRED",
                     "new small file contains at most one changed symbol and little structural reuse evidence",
-                    evidence={"changed_symbols": len(symbols), "code_lines": len(code_lines), "inbound_consumers": inbound_total},
+                    "introduced", evidence={"changed_symbols": len(symbols), "code_lines": len(code_lines), "inbound_consumers": inbound_total},
                 ))
     return findings
 
@@ -415,7 +477,7 @@ def detect_scope_findings(classifications: dict[str, dict[str, Any]]) -> list[Fi
     out = []
     for path, info in classifications.items():
         if info.get("class") == "UNJUSTIFIED":
-            out.append(Finding("UNJUSTIFIED_SCOPE", path, "MAJOR", 0.99, "DETERMINISTIC", "REVIEW_REQUIRED", info.get("reason") or "changed surface is not justified by active task scope"))
+            out.append(Finding("UNJUSTIFIED_SCOPE", path, "MAJOR", 0.99, "DETERMINISTIC", "REVIEW_REQUIRED", info.get("reason") or "changed surface is not justified by active task scope", "introduced"))
     return out
 
 
@@ -465,12 +527,85 @@ def coverage(graph: dict, diff_files: dict[str, DiffFile]) -> dict[str, Any]:
     }
 
 
+def _load_adjudication_payload(root: Path, spec: str | None) -> dict[str, Any]:
+    if spec:
+        candidate = Path(spec)
+        if candidate.exists():
+            try:
+                return json.loads(candidate.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                return {"schema_version": ADJUDICATION_SCHEMA_VERSION, "decisions": [], "error": "invalid adjudication file"}
+        try:
+            return json.loads(spec)
+        except json.JSONDecodeError:
+            return {"schema_version": ADJUDICATION_SCHEMA_VERSION, "decisions": [], "error": "invalid adjudication JSON"}
+    return read_json(state_root(root) / "runtime/slop-adjudications.json", {"schema_version": ADJUDICATION_SCHEMA_VERSION, "decisions": []})
+
+
+def _evidence_item_valid(root: Path, item: Any) -> bool:
+    if not isinstance(item, dict):
+        return False
+    kind = str(item.get("kind") or "source").lower()
+    if kind == "source":
+        path = str(item.get("path") or "")
+        return bool(path) and (root / path).exists()
+    if kind in {"task", "project_brain", "runtime", "test"}:
+        return bool(item.get("ref") or item.get("path") or item.get("detail"))
+    return False
+
+
+def apply_adjudications(root: Path, findings: list[Finding], payload: dict[str, Any]) -> dict[str, Any]:
+    decisions = payload.get("decisions", []) if isinstance(payload, dict) else []
+    accepted = invalid = unmatched = 0
+    for decision in decisions if isinstance(decisions, list) else []:
+        if not isinstance(decision, dict) or str(decision.get("decision") or "").upper() != "JUSTIFIED":
+            invalid += 1
+            continue
+        reason = str(decision.get("reason") or "").strip()
+        evidence = decision.get("evidence") or []
+        valid = len(reason) >= 12 and isinstance(evidence, list) and evidence and all(_evidence_item_valid(root, item) for item in evidence)
+        if not valid:
+            invalid += 1
+            continue
+        matched = False
+        for finding in findings:
+            if decision.get("rule") != finding.rule or decision.get("path") != finding.path:
+                continue
+            if decision.get("line") is not None and int(decision["line"]) != finding.line:
+                continue
+            if decision.get("symbol") and decision.get("symbol") != finding.symbol:
+                continue
+            finding.adjudication = {
+                "status": "accepted",
+                "decision": "JUSTIFIED",
+                "reason": reason,
+                "evidence": evidence,
+            }
+            matched = True
+        if matched:
+            accepted += 1
+        else:
+            unmatched += 1
+    return {
+        "schema_version": ADJUDICATION_SCHEMA_VERSION,
+        "accepted": accepted,
+        "invalid": invalid,
+        "unmatched": unmatched,
+        "provided": len(decisions) if isinstance(decisions, list) else 0,
+        "source": "explicit/default runtime adjudication payload",
+    }
+
+
+def _is_justified(finding: Finding) -> bool:
+    return bool(finding.adjudication and finding.adjudication.get("status") == "accepted")
+
+
 def risk_score(findings: list[Finding], scoreable: bool) -> int | None:
     if not scoreable:
         return None
     total = 0.0
     for f in findings:
-        if f.introduced not in {"introduced", "worsened"}:
+        if f.provenance not in {"introduced", "worsened"} or _is_justified(f):
             continue
         total += SEVERITY_WEIGHT.get(f.severity, 1) * f.confidence
     return min(100, int(round(total)))
@@ -480,7 +615,7 @@ def dedupe_findings(findings: list[Finding]) -> list[Finding]:
     seen = set()
     out = []
     for f in findings:
-        key = (f.rule, f.path, f.line, f.symbol, f.reason)
+        key = (f.rule, f.path, f.line, f.symbol, f.reason, f.provenance)
         if key in seen:
             continue
         seen.add(key)
@@ -490,16 +625,18 @@ def dedupe_findings(findings: list[Finding]) -> list[Finding]:
 
 def verdict(findings: list[Finding], protected: dict[str, Any]) -> str:
     for f in findings:
-        if f.introduced in {"introduced", "worsened"} and f.confidence >= 0.85 and (f.severity == "BLOCKER" or f.rule in BLOCKING_RULES):
+        if _is_justified(f):
+            continue
+        if f.provenance in {"introduced", "worsened"} and f.confidence >= 0.85 and (f.severity == "BLOCKER" or f.rule in BLOCKING_RULES):
             return "fail"
     if protected["underengineering_gate"]["status"] != "pass":
         return "review"
-    if any(f.severity == "MAJOR" and f.confidence >= 0.6 for f in findings):
+    if any(not _is_justified(f) and f.provenance in {"introduced", "worsened", "unknown"} and f.severity == "MAJOR" and f.confidence >= 0.6 for f in findings):
         return "review"
     return "pass"
 
 
-def analyze(root: Path, base: str | None = None, head: str | None = None) -> dict[str, Any]:
+def analyze(root: Path, base: str | None = None, head: str | None = None, adjudications: str | None = None) -> dict[str, Any]:
     root = root.resolve()
     state = state_root(root)
     task = read_json(state / "tasks/active.json", {})
@@ -511,16 +648,18 @@ def analyze(root: Path, base: str | None = None, head: str | None = None) -> dic
             diff_files.setdefault(path, diff_file)
     classifications = {path: classify_surface(path, task, graph) for path in sorted(diff_files)}
     idx = graph_indexes(graph)
-    findings = []
+    findings: list[Finding] = []
     findings.extend(detect_scope_findings(classifications))
     findings.extend(detect_line_findings(diff_files))
     findings.extend(detect_dependency_findings(root, scope, diff_files))
-    findings.extend(detect_structural_findings(root, graph, idx, diff_files))
+    findings.extend(detect_structural_findings(root, scope, graph, idx, diff_files))
     findings = dedupe_findings(findings)
+    adjudication_summary = apply_adjudications(root, findings, _load_adjudication_payload(root, adjudications))
     protected = protected_complexity(diff_files)
     cov = coverage(graph, diff_files)
     status = verdict(findings, protected)
     classes = Counter(x.get("class") for x in classifications.values())
+    provenance_counts = Counter(f.provenance for f in findings)
     return {
         "schema_version": SCHEMA_VERSION,
         "status": status,
@@ -537,7 +676,9 @@ def analyze(root: Path, base: str | None = None, head: str | None = None) -> dic
             "unjustified": classes.get("UNJUSTIFIED", 0),
         },
         "surface_classification": classifications,
+        "finding_provenance": {k: provenance_counts.get(k, 0) for k in sorted(PROVENANCE_VALUES)},
         "findings": [f.as_dict() for f in findings],
+        "adjudication": adjudication_summary,
         "protected_complexity": protected,
         "underengineering_gate": protected["underengineering_gate"],
     }
@@ -556,17 +697,20 @@ def human_report(report: dict[str, Any]) -> str:
         f"Status: {report['status'].upper()}",
         "",
         "Surfaces: " + ", ".join(f"{k}={v}" for k, v in report["surfaces"].items()),
+        "Finding provenance: " + ", ".join(f"{k}={v}" for k, v in report["finding_provenance"].items()),
+        f"Adjudication: accepted={report['adjudication']['accepted']}, invalid={report['adjudication']['invalid']}, unmatched={report['adjudication']['unmatched']}",
         f"Underengineering gate: {report['underengineering_gate']['status'].upper()}",
     ]
     findings = report.get("findings", [])
     if findings:
-        lines.extend(["", "Introduced findings:"])
+        lines.extend(["", "Findings:"])
         for f in findings:
             loc = f"{f['path']}:{f['line']}" if f.get("line") else f["path"]
             symbol = f" [{f['symbol']}]" if f.get("symbol") else ""
-            lines.append(f"- {f['severity']} {f['rule']} @ {loc}{symbol} ({f['confidence']:.0%})")
+            adjudicated = " JUSTIFIED" if (f.get("adjudication") or {}).get("status") == "accepted" else ""
+            lines.append(f"- {f['severity']} {f['rule']} @ {loc}{symbol} [{f['provenance']}] ({f['confidence']:.0%}){adjudicated}")
     else:
-        lines.extend(["", "Introduced findings: none"])
+        lines.extend(["", "Findings: none"])
     return "\n".join(lines)
 
 
@@ -575,11 +719,12 @@ def main() -> None:
     ap.add_argument("--root", default=".")
     ap.add_argument("--base")
     ap.add_argument("--head")
+    ap.add_argument("--adjudications", help="JSON string or path; defaults to .codemium/runtime/slop-adjudications.json")
     ap.add_argument("--json", action="store_true")
     ap.add_argument("--write-state", action="store_true")
     ap.add_argument("--strict", action="store_true")
     ns = ap.parse_args()
-    report = analyze(Path(ns.root), ns.base, ns.head)
+    report = analyze(Path(ns.root), ns.base, ns.head, ns.adjudications)
     if ns.write_state:
         write_json(state_root(Path(ns.root)) / "runtime/slop-report.json", report)
     print(json.dumps(report, indent=2, ensure_ascii=False) if ns.json else human_report(report))

--- a/plugins/codemium/engine/task_compiler.py
+++ b/plugins/codemium/engine/task_compiler.py
@@ -69,7 +69,7 @@ def compile_task(text: str, requested_depth: str = "auto", model: str | None = N
         "request": text, "objective": text.strip(), "expected_behavior": "derive from request/evidence before editing",
         "likely_domain": [], "acceptance": ["requested behavior is satisfied", "relevant verification passes", "no unrelated diff", "no material unexplained uncertainty"],
         "risk": r, "requested_depth": requested_depth.lower(), "depth": depth, "depth_reason": depth_reason,
-        "reasoning": reasoning, "change_policy": policy, "created_at": now_iso(), "working_set": [],
+        "reasoning": reasoning, "change_policy": policy, "created_at": now_iso(), "working_set": [], "cleanup_set": [],
     }
 
 

--- a/plugins/codemium/skills/codemium/references/slop-policy.md
+++ b/plugins/codemium/skills/codemium/references/slop-policy.md
@@ -13,6 +13,14 @@ Every changed surface must be defensible as one of:
 
 `UNJUSTIFIED` is an internal Slop Guard state, never a valid completion state. Before completion it must become justified by evidence or be removed.
 
+### CLEANUP is explicit
+
+Do not infer cleanup merely because a changed file looks old or redundant. A cleanup surface must be causally attributable to the current task.
+
+When deterministic task state is available, record caused cleanup paths in `tasks/active.json` as `cleanup_set`, or attach `working_set_evidence` with `kind: cleanup`. Slop Guard then classifies those paths as `CLEANUP` rather than treating them as ordinary direct work or unrelated scope.
+
+This mechanism is not permission for opportunistic cleanup. Pre-existing debt that was not made obsolete by the task remains out of scope.
+
 ## Guard before cleanup
 
 Normal source-changing Codemium tasks should run Slop Guard near completion against the actual task diff. Guard Mode is analysis-first. It must not turn a bounded feature/fix into repository-wide cleanup.
@@ -28,6 +36,19 @@ actual diff
 
 Pre-existing debt is reported separately when useful but is not automatically part of the task. Completion gates focus on slop introduced or worsened by the current task.
 
+## Finding provenance
+
+Every finding must carry one of:
+
+- `introduced` — the task added the suspicious engineering surface;
+- `worsened` — the surface existed, but the task made the relevant anti-slop property worse;
+- `pre_existing` — the suspicious property already existed before the task and was not introduced by it;
+- `unknown` — available evidence cannot safely determine provenance.
+
+Blocking gates target `introduced` and `worsened` findings. `pre_existing` findings do not become blockers merely because a task touched the same file. `unknown` major findings require review rather than fabricated certainty.
+
+For structural findings, Codemium should compare the changed symbol with the base revision when deterministic source parsing can establish whether the symbol/property already existed. Unsupported or ambiguous cases remain `unknown`.
+
 ## Evidence order
 
 Use the strongest available evidence:
@@ -37,6 +58,51 @@ Use the strongest available evidence:
 3. evidence-backed reasoning for ambiguity.
 
 Do not block or remove code because it merely "looks over-engineered." Source remains authoritative.
+
+## Evidence-backed adjudication
+
+Ambiguous blockers may be explicitly justified, but only with a recorded reason and concrete evidence. Slop Guard accepts adjudications from:
+
+```text
+.codemium/runtime/slop-adjudications.json
+```
+
+or an explicit CLI argument:
+
+```sh
+python plugins/codemium/engine/slop_guard.py \
+  --root . \
+  --adjudications .codemium/runtime/slop-adjudications.json \
+  --json
+```
+
+Minimum schema:
+
+```json
+{
+  "schema_version": 1,
+  "decisions": [
+    {
+      "rule": "UNJUSTIFIED_PUBLIC_API",
+      "path": "src/api.ts",
+      "line": 42,
+      "symbol": "createSession",
+      "decision": "JUSTIFIED",
+      "reason": "This export is required by the repository-owned public adapter contract.",
+      "evidence": [
+        {"kind": "source", "path": "src/adapters/public.ts"},
+        {"kind": "task", "detail": "acceptance requires the public adapter surface"}
+      ]
+    }
+  ]
+}
+```
+
+A `JUSTIFIED` decision is accepted only when it matches the finding, contains a substantive reason, and includes valid evidence. Accepted adjudication removes that finding from blocking/risk calculation; it does not delete the finding from the report.
+
+Do not use adjudication as a blanket waiver. Match the exact rule/path and, when available, line/symbol. Invalid or unmatched decisions remain visible in the report.
+
+**Adjudication never bypasses the Underengineering Counter-Gate.** Removing protected security, data-integrity, compatibility, concurrency, or verification logic still requires explicit review and re-verification.
 
 ## Coverage honesty
 
@@ -90,14 +156,21 @@ actual need
 
 A single implementation or single caller is only a signal. Architecture boundaries, public contracts, test seams, lifecycle separation, cross-language boundaries, or explicit project constraints can fully justify an abstraction.
 
+## Blocking calibration
+
+Blocking rules are deliberately high precision. Release validation must exercise positive, negative, provenance, adjudication, and protected-complexity cases. The repository calibration corpus lives at `benchmarks/v09-blocking-calibration.json` and is checked by `benchmarks/calibrate_v09_blocking.py`.
+
+That calibration validates gate semantics only. It is **not** a competitive benchmark and must not be published as an agent-performance or efficiency claim.
+
 ## Completion
 
 A source-changing task may complete when:
 
 - requested behavior is satisfied;
 - relevant verification passes;
-- no high-confidence introduced blocker remains unexplained;
+- no high-confidence introduced/worsened blocker remains unexplained;
 - every changed surface is justified;
+- any accepted adjudication is evidence-backed and recorded;
 - protected complexity has not been accidentally removed;
 - cleanup, if any, has been re-verified;
 - persistence/freshness obligations are satisfied.

--- a/plugins/codemium/skills/slop/SKILL.md
+++ b/plugins/codemium/skills/slop/SKILL.md
@@ -31,7 +31,56 @@ Do not accept or remove code merely because the aggregate risk score is high or 
 
 Classify every changed surface as `DIRECT`, `DEPENDENCY`, `CLEANUP`, or `TEST`. `UNJUSTIFIED` is temporary: either establish concrete task/architecture/safety evidence for it or remove it.
 
-Focus on engineering introduced or worsened by the current task. Do not turn a bounded task into a repository-wide cleanup campaign because unrelated historical slop exists nearby.
+A cleanup path must be caused by the current task. When task state is available, record it in `cleanup_set` or as `working_set_evidence` with `kind: cleanup`; do not call unrelated historical debt `CLEANUP` just to make the scope pass.
+
+Focus on engineering introduced or worsened by the current task. Read finding `provenance` explicitly:
+
+- `introduced` / `worsened` can gate completion;
+- `pre_existing` is historical debt unless the user asked to clean it;
+- `unknown` requires source review rather than guessed provenance.
+
+Do not turn a bounded task into a repository-wide cleanup campaign because unrelated historical slop exists nearby.
+
+## Evidence-backed adjudication
+
+When a blocker is ambiguous but legitimate engineering is supported by repository/task evidence, record a narrow `JUSTIFIED` adjudication rather than weakening the rule globally.
+
+Default file:
+
+```text
+.codemium/runtime/slop-adjudications.json
+```
+
+Example:
+
+```json
+{
+  "schema_version": 1,
+  "decisions": [
+    {
+      "rule": "DUPLICATE_IMPLEMENTATION",
+      "path": "src/adapter.py",
+      "symbol": "normalize_value",
+      "decision": "JUSTIFIED",
+      "reason": "This implementation is intentionally isolated at the adapter boundary.",
+      "evidence": [
+        {"kind": "source", "path": "src/adapter.py"},
+        {"kind": "task", "detail": "the adapter must remain dependency-isolated"}
+      ]
+    }
+  ]
+}
+```
+
+Then re-run:
+
+```sh
+python engine/slop_guard.py --root . --adjudications .codemium/runtime/slop-adjudications.json --json
+```
+
+An adjudication must match the exact finding and include a substantive reason plus concrete evidence. Invalid/unmatched decisions do not waive anything. Accepted adjudication stays visible in the report and is excluded from blocking/risk calculation.
+
+Never use adjudication to bypass the **Underengineering Counter-Gate**.
 
 ## Cleanup
 
@@ -53,7 +102,8 @@ Report:
 
 - diff scope used;
 - pass/review/fail result;
-- introduced/worsened findings that matter;
+- finding provenance that matters;
+- adjudications accepted/invalid/unmatched;
 - any protected complexity intentionally retained;
 - cleanup performed, if any;
 - verification repeated after cleanup;

--- a/plugins/codemium/tests/test_slop_guard.py
+++ b/plugins/codemium/tests/test_slop_guard.py
@@ -31,21 +31,30 @@ def commit(root: Path, message: str = "initial") -> None:
     run("git", "commit", "-qm", message, cwd=root)
 
 
+def write_state(root: Path, task: dict, graph: dict) -> None:
+    state = root / ".codemium"
+    (state / "tasks").mkdir(parents=True)
+    (state / "repository").mkdir()
+    (state / "tasks/active.json").write_text(json.dumps(task), encoding="utf-8")
+    (state / "repository/graph.json").write_text(json.dumps(graph), encoding="utf-8")
+
+
 def main() -> None:
-    # Introduced-slop fixture: task scope, line-level smells, dependency delta,
-    # duplicate implementation, single-use forwarder, and untracked source files
-    # must all be visible to the gate.
+    # Introduced/worsened fixture: task scope, cleanup classification, line smells,
+    # dependency delta, duplicate implementation, single-use forwarder, adjudication,
+    # and untracked source files must all be visible to the gate.
     with tempfile.TemporaryDirectory() as td:
         root = Path(td)
         (root / "src").mkdir()
         init_repo(root)
         (root / "src/utils.py").write_text("def normalize_value(x):\n    return x\n", encoding="utf-8")
-        (root / "src/service.py").write_text("def process(x):\n    return x\n", encoding="utf-8")
-        (root / "src/unrelated.py").write_text("def untouched():\n    return 1\n", encoding="utf-8")
-        (root / "src/security.py").write_text(
-            "def validate_token(token):\n    if not token:\n        raise ValueError('token')\n    return token\n",
+        (root / "src/service.py").write_text(
+            "def process(x):\n    return x\n\n"
+            "def pass_through(x):\n    return x\n",
             encoding="utf-8",
         )
+        (root / "src/cleanup.py").write_text("OLD_FLAG = True\n", encoding="utf-8")
+        (root / "src/unrelated.py").write_text("def untouched():\n    return 1\n", encoding="utf-8")
         (root / "package.json").write_text(json.dumps({"dependencies": {}}, indent=2) + "\n", encoding="utf-8")
         commit(root)
 
@@ -59,22 +68,22 @@ def main() -> None:
             "value = None  # type: ignore\n",
             encoding="utf-8",
         )
+        (root / "src/cleanup.py").write_text("OLD_FLAG = False\n", encoding="utf-8")
         (root / "src/unrelated.py").write_text("def untouched():\n    return 2\n", encoding="utf-8")
         (root / "src/new_helper.py").write_text("def new_helper():\n    return True\n", encoding="utf-8")
         (root / "package.json").write_text(
             json.dumps({"dependencies": {"left-pad": "1.3.0"}}, indent=2) + "\n", encoding="utf-8"
         )
 
-        state = root / ".codemium"
-        (state / "tasks").mkdir(parents=True)
-        (state / "repository").mkdir()
-        (state / "tasks/active.json").write_text(
-            json.dumps({"working_set": ["src/service.py", "package.json"]}), encoding="utf-8"
-        )
+        task = {
+            "working_set": ["src/service.py", "package.json"],
+            "cleanup_set": ["src/cleanup.py"],
+        }
         graph = {
             "files": [
                 {"path": "src/service.py", "language": "python", "is_test": False, "parser": "python-ast", "capabilities": {"symbols": True}},
                 {"path": "src/utils.py", "language": "python", "is_test": False, "parser": "python-ast", "capabilities": {"symbols": True}},
+                {"path": "src/cleanup.py", "language": "python", "is_test": False, "parser": "python-ast", "capabilities": {"symbols": True}},
                 {"path": "src/unrelated.py", "language": "python", "is_test": False, "parser": "python-ast", "capabilities": {"symbols": True}},
             ],
             "nodes": [
@@ -88,7 +97,7 @@ def main() -> None:
                 {"source": "s:svc:pass", "target": "s:svc:norm", "relation": "CALLS", "provenance": "RESOLVED"}
             ],
         }
-        (state / "repository/graph.json").write_text(json.dumps(graph), encoding="utf-8")
+        write_state(root, task, graph)
 
         p = run(sys.executable, ENGINE / "slop_guard.py", "--root", root, "--base", "HEAD", "--json")
         report = json.loads(p.stdout)
@@ -104,11 +113,52 @@ def main() -> None:
         ]:
             assert rule in rules, (rule, rules)
         assert report["status"] == "fail", report
-        assert report["changed_files"] == 4, report["surface_classification"]
+        assert report["changed_files"] == 5, report["surface_classification"]
+        assert report["surfaces"]["cleanup"] == 1
+        assert report["surface_classification"]["src/cleanup.py"]["class"] == "CLEANUP"
         assert report["surfaces"]["unjustified"] == 2
         assert report["surface_classification"]["src/new_helper.py"]["class"] == "UNJUSTIFIED"
         assert report["scoreable"] is True and report["risk_score"] is not None
         assert report["underengineering_gate"]["status"] == "pass"
+        duplicate = next(f for f in report["findings"] if f["rule"] == "DUPLICATE_IMPLEMENTATION")
+        forwarder = next(f for f in report["findings"] if f["rule"] == "SINGLE_USE_FORWARDER" and f.get("symbol") == "pass_through")
+        assert duplicate["provenance"] == "introduced", duplicate
+        assert forwarder["provenance"] == "worsened", forwarder
+        assert set(report["finding_provenance"]) == {"introduced", "worsened", "pre_existing", "unknown"}
+
+        decisions = {"schema_version": 1, "decisions": []}
+        for finding in report["findings"]:
+            if finding["rule"] not in {"UNJUSTIFIED_SCOPE", "UNJUSTIFIED_DEPENDENCY", "DUPLICATE_IMPLEMENTATION"}:
+                continue
+            evidence_path = finding["path"] if (root / finding["path"]).exists() else "src/service.py"
+            decisions["decisions"].append({
+                "rule": finding["rule"],
+                "path": finding["path"],
+                "line": finding.get("line"),
+                "symbol": finding.get("symbol"),
+                "decision": "JUSTIFIED",
+                "reason": "Source and task evidence show this surface is required for the requested behavior.",
+                "evidence": [{"kind": "source", "path": evidence_path}],
+            })
+        p = run(
+            sys.executable,
+            ENGINE / "slop_guard.py",
+            "--root",
+            root,
+            "--base",
+            "HEAD",
+            "--adjudications",
+            json.dumps(decisions),
+            "--json",
+        )
+        adjudicated = json.loads(p.stdout)
+        assert adjudicated["adjudication"]["accepted"] == len(decisions["decisions"]), adjudicated["adjudication"]
+        assert all(
+            (f.get("adjudication") or {}).get("status") == "accepted"
+            for f in adjudicated["findings"]
+            if f["rule"] in {"UNJUSTIFIED_SCOPE", "UNJUSTIFIED_DEPENDENCY", "DUPLICATE_IMPLEMENTATION"}
+        )
+        assert adjudicated["status"] == "review", adjudicated
 
         strict = run(
             sys.executable,
@@ -123,35 +173,70 @@ def main() -> None:
         )
         assert strict.returncode == 3, strict.returncode
 
-    # Underengineering fixture: removing protected complexity must force review,
-    # and a score must not be fabricated when there are no scoreable added source lines.
+    # Pre-existing structural debt is explicit provenance and does not become a
+    # blocker merely because the task touched the existing function.
     with tempfile.TemporaryDirectory() as td:
         root = Path(td)
         (root / "src").mkdir()
         init_repo(root)
-        (root / "src/security.py").write_text(
-            "def validate_token(token):\n    if not token:\n        raise ValueError('token required')\n    return token\n",
-            encoding="utf-8",
-        )
+        (root / "src/a.py").write_text("def same(x):\n    return x\n", encoding="utf-8")
+        (root / "src/b.py").write_text("def same(x):\n    return x\n", encoding="utf-8")
         commit(root)
-        (root / "src/security.py").write_text("def validate_token(token):\n    return token\n", encoding="utf-8")
-
-        state = root / ".codemium"
-        (state / "tasks").mkdir(parents=True)
-        (state / "repository").mkdir()
-        (state / "tasks/active.json").write_text(json.dumps({"working_set": ["src/security.py"]}), encoding="utf-8")
+        (root / "src/b.py").write_text("def same(x):\n    return x + 1\n", encoding="utf-8")
         graph = {
             "files": [
-                {"path": "src/security.py", "language": "python", "is_test": False, "parser": "python-ast", "capabilities": {"symbols": True}}
+                {"path": "src/a.py", "language": "python", "is_test": False, "parser": "python-ast", "capabilities": {"symbols": True}},
+                {"path": "src/b.py", "language": "python", "is_test": False, "parser": "python-ast", "capabilities": {"symbols": True}},
+            ],
+            "nodes": [
+                {"id": "s:a:same", "type": "SYMBOL", "subtype": "function", "label": "same", "qualified_name": "same", "path": "src/a.py", "line_start": 1, "line_end": 2},
+                {"id": "s:b:same", "type": "SYMBOL", "subtype": "function", "label": "same", "qualified_name": "same", "path": "src/b.py", "line_start": 1, "line_end": 2},
+            ],
+            "edges": [],
+        }
+        write_state(root, {"working_set": ["src/b.py"]}, graph)
+        p = run(sys.executable, ENGINE / "slop_guard.py", "--root", root, "--base", "HEAD", "--json")
+        report = json.loads(p.stdout)
+        duplicate = next(f for f in report["findings"] if f["rule"] == "DUPLICATE_IMPLEMENTATION")
+        assert duplicate["provenance"] == "pre_existing", duplicate
+        assert report["status"] == "pass", report
+
+    # Underengineering fixture spans protected complexity classes. Removing these
+    # signals must force review, while adding them is not itself an Anti-Slop failure.
+    protected_lines = [
+        "authorize(user)",
+        "validate(payload)",
+        "sanitize(payload)",
+        "rate_limit(user)",
+        "transaction.begin()",
+        "lock.acquire()",
+        "idempotency_key = key",
+        "retry(request)",
+        "migration.apply()",
+        "compatibility_shim()",
+        "integrity_check()",
+        "csrf_check()",
+    ]
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        (root / "src").mkdir()
+        init_repo(root)
+        before = "def guarded():\n" + "".join(f"    {line}\n" for line in protected_lines) + "    return True\n"
+        (root / "src/safety.py").write_text(before, encoding="utf-8")
+        commit(root)
+        (root / "src/safety.py").write_text("def guarded():\n    return True\n", encoding="utf-8")
+        graph = {
+            "files": [
+                {"path": "src/safety.py", "language": "python", "is_test": False, "parser": "python-ast", "capabilities": {"symbols": True}}
             ],
             "nodes": [],
             "edges": [],
         }
-        (state / "repository/graph.json").write_text(json.dumps(graph), encoding="utf-8")
-
+        write_state(root, {"working_set": ["src/safety.py"]}, graph)
         p = run(sys.executable, ENGINE / "slop_guard.py", "--root", root, "--base", "HEAD", "--json")
         report = json.loads(p.stdout)
         assert report["underengineering_gate"]["status"] == "review_required", report
+        assert len(report["protected_complexity"]["removed"]) >= 10, report["protected_complexity"]
         assert report["status"] == "review", report
         assert report["risk_score"] is None and report["scoreable"] is False
 
@@ -171,11 +256,6 @@ def main() -> None:
             "class B:\n    def save(self, value):\n        return value\n",
             encoding="utf-8",
         )
-
-        state = root / ".codemium"
-        (state / "tasks").mkdir(parents=True)
-        (state / "repository").mkdir()
-        (state / "tasks/active.json").write_text(json.dumps({"working_set": ["src/b.py"]}), encoding="utf-8")
         graph = {
             "files": [
                 {"path": "src/a.py", "language": "python", "is_test": False, "parser": "python-ast", "capabilities": {"symbols": True}},
@@ -187,14 +267,13 @@ def main() -> None:
             ],
             "edges": [],
         }
-        (state / "repository/graph.json").write_text(json.dumps(graph), encoding="utf-8")
-
+        write_state(root, {"working_set": ["src/b.py"]}, graph)
         p = run(sys.executable, ENGINE / "slop_guard.py", "--root", root, "--base", "HEAD", "--json")
         report = json.loads(p.stdout)
         duplicate_methods = [f for f in report["findings"] if f["rule"] == "DUPLICATE_IMPLEMENTATION" and f.get("symbol") == "save"]
         assert duplicate_methods == [], duplicate_methods
 
-    print("PASS: Codemium v0.9 Slop Guard tracked/untracked + structural + underengineering fixture")
+    print("PASS: Codemium v0.9 Slop Guard provenance + adjudication + cleanup + protected-complexity fixture")
 
 
 if __name__ == "__main__":

--- a/scripts/verify_core.py
+++ b/scripts/verify_core.py
@@ -45,6 +45,7 @@ def main() -> None:
 
     fixture = TESTS / "test_core_fixture.py"
     slop_fixture = TESTS / "test_slop_guard.py"
+    calibration = ROOT / "benchmarks/calibrate_v09_blocking.py"
 
     brain = (ENGINE / "project_brain.py").read_text(encoding="utf-8")
     for phrase in ["GENERIC_REASONING", "TRANSIENT_IGNORE", "tasks/active.json", "host_profiles", "def capture(", "find_active_duplicate", "init(root, emit=False)", "def entry_freshness(", "NEEDS_REVALIDATION", "def revalidate("]:
@@ -81,8 +82,9 @@ def main() -> None:
 
     slop = (ENGINE / "slop_guard.py").read_text(encoding="utf-8")
     for phrase in [
-        "SCHEMA_VERSION = 1", "UNJUSTIFIED_SCOPE", "DUPLICATE_IMPLEMENTATION", "UNJUSTIFIED_DEPENDENCY",
-        "UNJUSTIFIED_PUBLIC_API", "protected_complexity", "underengineering_gate", "scoreable", "risk_score", "--strict",
+        "SCHEMA_VERSION = 1", "ADJUDICATION_SCHEMA_VERSION = 1", "PROVENANCE_VALUES", "UNJUSTIFIED_SCOPE",
+        "DUPLICATE_IMPLEMENTATION", "UNJUSTIFIED_DEPENDENCY", "UNJUSTIFIED_PUBLIC_API", "cleanup_set",
+        "protected_complexity", "underengineering_gate", "scoreable", "risk_score", "--adjudications", "--strict",
     ]:
         if phrase not in slop:
             fail(f"Anti-Slop contract missing: {phrase}")
@@ -102,6 +104,7 @@ def main() -> None:
 
     run_fixture(fixture, "host-agnostic core")
     run_fixture(slop_fixture, "v0.9 Slop Guard")
+    run_fixture(calibration, "v0.9 blocking calibration")
 
     print(json.dumps({
         "status": "pass", "version": version, "scope": "codemium-core",
@@ -115,7 +118,10 @@ def main() -> None:
             "automatic Project Brain initialization/capture",
             "generic task/depth contract",
             "task-aware Slop Guard + coverage honesty",
+            "finding provenance + evidence-backed adjudication",
+            "CLEANUP surface classification",
             "Underengineering Counter-Gate",
+            "blocking-rule calibration corpus",
             "host-agnostic core + Anti-Slop fixtures",
         ],
     }, indent=2))


### PR DESCRIPTION
Continues #15.

## Remaining release gates implemented

- explicit finding provenance: `introduced`, `worsened`, `pre_existing`, `unknown`;
- base-revision structural provenance so touched historical debt does not become a new blocker;
- explicit `CLEANUP` task surfaces through `cleanup_set` / cleanup working-set evidence;
- evidence-backed `JUSTIFIED` adjudication via `.codemium/runtime/slop-adjudications.json` or `--adjudications`;
- adjudication validation requires exact finding match, substantive reason, and concrete evidence;
- accepted adjudications stay visible but are removed from blocker/risk calculation;
- adjudication cannot bypass the Underengineering Counter-Gate;
- expanded protected-complexity detection/fixtures across authorization, validation, sanitization, rate limiting, transactions, locking, idempotency, retry, migration, compatibility, integrity, and security signals;
- release blocker calibration corpus + deterministic calibration runner included in Core CI;
- benchmark documentation explicitly separates release gate calibration from future measured multi-arm competitive claims.

## Safety/precision behavior

- only `introduced` / `worsened` high-confidence blockers fail the gate;
- `pre_existing` debt is non-blocking by default;
- `unknown` major findings require review rather than fabricated certainty;
- protected complexity removal remains review-required even if another finding is adjudicated;
- no numeric competitive Anti-Slop claim is introduced by this PR.

`VERSION` intentionally remains `0.8.0` in this PR. If CI passes and the release-gate behavior is clean, the next release PR can bump host manifests/docs to `0.9.0`.